### PR TITLE
Use the package's own copy of Babel

### DIFF
--- a/lib/babel-transpiler.coffee
+++ b/lib/babel-transpiler.coffee
@@ -137,7 +137,7 @@ module.exports = BabelTranspile =
       babelOptions.whitelist = config.whitelistTransformers
 
     # babel-core seems to add a lot of time to atom loading so delay until needed
-    @babel ?= require('babel-core')
+    @babel ?= require('../node_modules/babel-core')
     @babel.transformFile fqName.sourceFile, babelOptions, (err,result) ->
       if err
         atom.notifications.addError 'Babel Transpiler Error', { dismissable: true, detail: err.message}


### PR DESCRIPTION
`require('babel-core')` resolves to the one bundled with Atom, rather than the one installed as a dependency.  If we explicitly load the latter instead, the user can update it more easily when needed (e.g. I use some Babel 5.4 features in my codebase, while Atom ships 5.3.3).