### PR TITLE
module keywords are 'control' not 'operator'

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -1159,7 +1159,7 @@
     "literal-module": {
       "patterns": [
         {
-          "name": "keyword.operator.module.js",
+          "name": "keyword.control.module.js",
           "match": "(?<!\\.)\\b(import|export|default|from|as)\\b"
         }
       ]


### PR DESCRIPTION
`language-java` uses `keyword.other.import.java` but `language-javascript` is using `keyword.control.js` so I went with `control`

### before
![screenshot from 2015-07-18 02 10 38](https://cloud.githubusercontent.com/assets/3265539/8760723/545de4d6-2cf2-11e5-9b88-7aa7a8ced4a2.png)

### after
![screenshot from 2015-07-18 02 10 53](https://cloud.githubusercontent.com/assets/3265539/8760725/57d3ecb4-2cf2-11e5-9565-c2a619184b5b.png)