### PR TITLE
fix class braces and class bodies

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -770,6 +770,7 @@
             {
               "begin": "{",
               "end": "(?=})",
+              "contentName": "meta.class.body.js",
               "beginCaptures": {
                 "0": { "name": "meta.brace.curly.js" }
               },

--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -753,7 +753,7 @@
             "2": { "name": "entity.name.class.js" }
           },
           "endCaptures": {
-            "0": { "name": "meta.brace.curly.js" }
+            "0": { "name": "punctuation.section.class.end.js" }
           },
           "patterns": [
             {
@@ -772,7 +772,7 @@
               "end": "(?=})",
               "contentName": "meta.class.body.js",
               "beginCaptures": {
-                "0": { "name": "meta.brace.curly.js" }
+                "0": { "name": "punctuation.section.class.begin.js" }
               },
               "patterns": [
                 { "include": "#brackets" },


### PR DESCRIPTION
Currently, javascript classes are getting the classname color as the default color for everything inside them because of `meta.class`. `meta.class.body` is used to reset that back to normal. But even then the opening brace was still getting `meta.class` color until I tagged the braces with `punctuation.section.class`.

### before
![screenshot from 2015-07-18 02 22 02](https://cloud.githubusercontent.com/assets/3265539/8760768/0b535350-2cf4-11e5-9030-f7f0ebfe9586.png)

### after
![screenshot from 2015-07-18 02 22 19](https://cloud.githubusercontent.com/assets/3265539/8760769/1036ca64-2cf4-11e5-88cf-d33bb1214a3c.png)
