### PR TITLE
syntax themes don't have rules for methods specifically, just functions

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -1074,14 +1074,14 @@
       "patterns": [
         {
           "comment": " e.g. play(arg1, arg2) {  }",
-          "name": "meta.method.js",
+          "name": "meta.function.method.js",
           "begin": "(?:\\b(static)\\s+)?(?:\\b(async)\\s+)?(?:(\\*)\\s*)?([_$a-zA-Z][$\\w]*)\\s*(?=\\([^())]*\\)(?:\\s|/\\*.*\\*/)*\\{)",
           "end": "(?<=\\))",
           "beginCaptures": {
             "1": { "name": "storage.type.js" },
             "2": { "name": "storage.type.js" },
             "3": { "name": "keyword.generator.asterisk.js" },
-            "4": { "name": "entity.name.method.js" }
+            "4": { "name": "entity.name.function.method.js" }
           },
           "patterns": [
             { "include": "#function-declaration-parameters" }


### PR DESCRIPTION
Grammars for other languages seem to just use `meta.function.<language>` but quoting the TextMate manual:

> ...you should re-use the existing names ... You should however append as much information to the sub-type you choose.

so I kept .method as additional information just in case.

### before
![screenshot from 2015-07-18 05 58 46](https://cloud.githubusercontent.com/assets/3265539/8761339/4584dcb0-2d12-11e5-9063-c46ee29c0f32.png)

### after
![screenshot from 2015-07-18 05 59 42](https://cloud.githubusercontent.com/assets/3265539/8761340/48ccf5f6-2d12-11e5-8043-ffd1398639c9.png)