### PR TITLE
improve labeling of embedded js section inside jsx

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -1386,15 +1386,16 @@
       ]
     },
     "jsx-evaluated-code": {
-      "name": "meta.brace.curly.js",
+      "name": "meta.embedded.expression.js",
       "begin": "{",
       "end": "}",
       "beginCaptures": {
-        "0": { "name": "punctuation.definition.brace.curly.start.jsx" }
+        "0": { "name": "punctuation.section.embedded.begin.jsx" }
       },
       "endCaptures": {
-        "0": { "name": "punctuation.definition.brace.curly.end.jsx" }
+        "0": { "name": "punctuation.section.embedded.end.jsx" }
       },
+      "contentName": "source.js.jsx",
       "patterns": [
         { "include": "#jsx-string-double-quoted" },
         { "include": "#jsx-string-single-quoted" },


### PR DESCRIPTION
This is consistent with how `language-javascript-jsx` [does it](https://github.com/subtleGradient/language-javascript-jsx/blob/4209756ea698a281f4176cac7f610af6847c54f0/grammars/JavaScript%20with%20JSX.cson#L23-L39), which is the same as how `language-php` labels [PHP sections in HTML](https://github.com/atom/language-php/blob/59385bb9186ede9c9bb7f788c5f80f2cc206d81a/grammars/php.cson#L33-L51), or `language-ruby` labeling [Ruby in HTML](https://github.com/atom/language-ruby/blob/32cf069f0363558b29918d1fc50039c2d70f38ef/grammars/html%20(ruby%20-%20erb).cson#L69-L94)

Related: https://github.com/atom/one-dark-syntax/issues/42