### PR TITLE
Rename Javascript in grammar to correct language name JavaScript

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -1,5 +1,5 @@
 {
-  "name": "Babel ES6 Javascript",
+  "name": "Babel ES6 JavaScript",
   "comment": "27Apr15",
   "scopeName": "source.js.jsx",
   "foldingStartMarker": "(/\\*|\\{|\\()",


### PR DESCRIPTION
The grammar is `Babel ES6 Javascript` although it should be `Babel ES6 JavaScript`.

---

Related issue: https://github.com/Glavin001/atom-preview/issues/108#issuecomment-127642971
I'd prefer to fix the mistyped `Javascript` in `language-babel` instead of switching Atom Preview's usage from `Babel ES6 JavaScript` to using `Javascript` incorrectly as well.

Thanks!