### PR TITLE
"keyword.operator.assignment" fixes

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -1096,7 +1096,7 @@
           "applyEndPatternLast": "1",
           "beginCaptures": {
             "1": { "name": "entity.name.function.js" },
-            "2": { "name": "keyword.operator.equals.js"},
+            "2": { "name": "keyword.operator.assignment.js"},
             "3": { "name": "storage.type.js" }
           },
           "endCaptures": {
@@ -1112,9 +1112,9 @@
           "begin": "\\s*(\\b[_$a-zA-Z][$\\w]*)\\s*(=)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*([_$a-zA-Z][$\\w]*)\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
           "beginCaptures": {
-            "1": {"name": "entity.name.function.js"},
-            "2": { "name": "keyword.operator.equals.js"},
-            "3": {"name": "storage.type.js"}
+            "1": { "name": "entity.name.function.js" },
+            "2": { "name": "keyword.operator.assignment.js" },
+            "3": { "name": "storage.type.js" }
           },
           "endCaptures": {
             "1": { "name": "storage.type.function.arrow.js" }
@@ -1136,7 +1136,7 @@
             "3": { "name": "variable.language.prototype.js" },
             "4": { "name": "keyword.operator.accessor.js" },
             "5": { "name": "entity.name.function.js" },
-            "6": { "name": "keyword.operator.equals.js"},
+            "6": { "name": "keyword.operator.assignment.js" },
             "7": { "name": "storage.type.js" }
           },
           "endCaptures": {
@@ -1152,12 +1152,12 @@
           "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)(prototype)(\\.)([_$a-zA-Z][$\\w]*)\\s*(=)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*([_$a-zA-Z][$\\w]*)\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
           "beginCaptures": {
-            "1": {"name": "entity.name.class.js"},
-            "2": {"name": "keyword.operator.accessor.js"},
-            "3": {"name": "variable.language.prototype.js"},
-            "4": {"name": "keyword.operator.accessor.js"},
-            "5": {"name": "entity.name.function.js"},
-            "6": { "name": "keyword.operator.equals.js"},
+            "1": { "name": "entity.name.class.js" },
+            "2": { "name": "keyword.operator.accessor.js" },
+            "3": { "name": "variable.language.prototype.js" },
+            "4": { "name": "keyword.operator.accessor.js" },
+            "5": { "name": "entity.name.function.js" },
+            "6": { "name": "keyword.operator.assignment.js" },
             "7": { "name": "storage.type.js" }
           },
           "endCaptures": {
@@ -1178,8 +1178,8 @@
             "1": { "name": "entity.name.class.js" },
             "2": { "name": "keyword.operator.accessor.js" },
             "3": { "name": "entity.name.function.js" },
-            "4": {"name": "keyword.operator.accessor.js"},
-            "5": {"name": "storage.type.js"}
+            "4": { "name": "keyword.operator.assignment.js" },
+            "5": { "name": "storage.type.js" }
 
           },
           "endCaptures": {
@@ -1198,8 +1198,8 @@
             "1": { "name": "entity.name.class.js" },
             "2": { "name": "keyword.operator.accessor.js" },
             "3": { "name": "entity.name.function.js" },
-            "4": {"name": "keyword.operator.accessor.js"},
-            "5": {"name": "storage.type.js"}
+            "4": { "name": "keyword.operator.assignment.js" },
+            "5": { "name": "storage.type.js" }
           },
           "endCaptures": {
             "1": { "name": "storage.type.function.arrow.js" }

--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -566,15 +566,16 @@
         {
           "comment": "e.g. play = function(arg1, arg2) {  }",
           "name": "meta.function.js",
-          "begin": "\\s*(\\b[_$a-zA-Z][$\\w]*)\\s*=\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
+          "begin": "\\s*(\\b[_$a-zA-Z][$\\w]*)\\s*(=)\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
           "end": "(?=\\s*\\{)",
           "applyEndPatternLast": "1",
           "beginCaptures": {
             "1": { "name": "entity.name.function.js" },
-            "2": { "name": "storage.type.js" },
-            "3": { "name": "storage.type.function.js" },
-            "4": { "name": "keyword.generator.asterisk.js" },
-            "5": { "name": "entity.name.function.js" }
+            "2": { "name": "keyword.operator.assignment.js" },
+            "3": { "name": "storage.type.js" },
+            "4": { "name": "storage.type.function.js" },
+            "5": { "name": "keyword.generator.asterisk.js" },
+            "6": { "name": "entity.name.function.js" }
           },
           "patterns": [
             { "include": "#flowtype" }
@@ -583,7 +584,7 @@
         {
           "comment": "e.g. Sound.prototype.play = function(arg1, arg2) {  }",
           "name": "meta.prototype.function.js",
-          "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)(prototype)(\\.)([_$a-zA-Z][$\\w]*)\\s*=\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
+          "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)(prototype)(\\.)([_$a-zA-Z][$\\w]*)\\s*(=)\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
           "end": "(?=\\s*\\{)",
           "applyEndPatternLast": "1",
           "beginCaptures": {
@@ -592,10 +593,11 @@
             "3": { "name": "variable.language.prototype.js" },
             "4": { "name": "keyword.operator.accessor.js" },
             "5": { "name": "entity.name.function.js" },
-            "6": { "name": "storage.type.js" },
-            "7": { "name": "storage.type.function.js" },
-            "8": { "name": "keyword.generator.asterisk.js" },
-            "9": { "name": "entity.name.function.js" }
+            "6": { "name": "keyword.operator.assignment.js" },
+            "7": { "name": "storage.type.js" },
+            "8": { "name": "storage.type.function.js" },
+            "9": { "name": "keyword.generator.asterisk.js" },
+            "10": { "name": "entity.name.function.js" }
           },
           "patterns": [
             { "include": "#flowtype" }
@@ -604,17 +606,18 @@
         {
           "comment": "e.g. Sound.play = function(arg1, arg2) {  }",
           "name": "meta.function.static.js",
-          "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)([_$a-zA-Z][$\\w]*)\\s*=\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
+          "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)([_$a-zA-Z][$\\w]*)\\s*(=)\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
           "end": "(?=\\s*\\{)",
           "applyEndPatternLast": "1",
           "beginCaptures": {
             "1": { "name": "entity.name.class.js" },
             "2": { "name": "keyword.operator.accessor.js" },
             "3": { "name": "entity.name.function.js" },
-            "4": { "name": "storage.type.js" },
-            "5": { "name": "storage.type.function.js" },
-            "6": { "name": "keyword.generator.asterisk.js" },
-            "7": { "name": "entity.name.function.js" }
+            "4": { "name": "keyword.operator.assignment.js" },
+            "5": { "name": "storage.type.js" },
+            "6": { "name": "storage.type.function.js" },
+            "7": { "name": "keyword.generator.asterisk.js" },
+            "8": { "name": "entity.name.function.js" }
           },
           "patterns": [
             { "include": "#flowtype" }


### PR DESCRIPTION
* Add missing `keyword.operator.assignment` in `#literal-function`
* Standardize around `keyword.operator.assignment`
  - Since there seems to be precedent for calling it `assignment` instead of `equals` in `#jsx-assignment` and in `#flowtype-parse-operators`.

before and after:
![compare](https://cloud.githubusercontent.com/assets/830952/10011538/9615224e-60b0-11e5-984c-2124bd713f84.png)

You can find that file at https://github.com/babel/babel-sublime/blob/v8.2.1/samples/js-functions.js

I love the work you've done here! I'm going to port some of it over to babel-sublime :smile: 
