### PR TITLE
Switch "applyEndPatternLast" type to int

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -65,7 +65,7 @@
           "name": "meta.function.json.js",
           "begin": "\\s*([_$a-zA-Z][$\\w]*)\\s*(:)\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(?:(\\*)\\s*)?\\s*(?=\\(|<)",
           "end": "(?=\\{)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "entity.name.function.js" },
             "2": { "name": "punctuation.separator.key-value.js" },
@@ -82,7 +82,7 @@
           "name": "meta.function.json.js",
           "begin": "\\s*(('|\\\")(\\b[_$a-zA-Z][$\\w]*)(\\k<2>))\\s*(:)\\s*(async)?\\s+(\\bfunction\\b)\\s*(\\*\\s*)?\\s*(?=\\(|<)",
           "end": "(?=\\{)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "string.quoted.js" },
             "2": { "name": "punctuation.definition.string.begin.js" },
@@ -106,7 +106,7 @@
           "name": "meta.function.json.arrow.js",
           "begin": "\\s*(\\b[_$a-zA-Z][$\\w]*)\\s*(:)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*(\\((?:(?>[^()]+)|\\g<-1>)*\\))\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "entity.name.function.js" },
             "2": { "name": "punctuation.separator.key-value.js" },
@@ -142,7 +142,7 @@
           "name": "meta.function.json.arrow.js",
           "begin": "\\s*(('|\\\")(\\b[_$a-zA-Z][$\\w]*)(\\k<2>))\\s*(:)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*(\\((?:(?>[^()]+)|\\g<-1>)*\\))\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "endCaptures": {
             "1": { "name": "storage.type.function.arrow.js" }
           },
@@ -552,7 +552,7 @@
           "name": "meta.function.js",
           "begin": "\\s*(?:\\b(async)\\b\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
           "end": "(?=\\s*\\{)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "storage.type.js" },
             "2": { "name": "storage.type.function.js" },
@@ -568,7 +568,7 @@
           "name": "meta.function.js",
           "begin": "\\s*(\\b[_$a-zA-Z][$\\w]*)\\s*(=)\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
           "end": "(?=\\s*\\{)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "entity.name.function.js" },
             "2": { "name": "keyword.operator.assignment.js" },
@@ -586,7 +586,7 @@
           "name": "meta.prototype.function.js",
           "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)(prototype)(\\.)([_$a-zA-Z][$\\w]*)\\s*(=)\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
           "end": "(?=\\s*\\{)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "entity.name.class.js" },
             "2": { "name": "keyword.operator.accessor.js" },
@@ -608,7 +608,7 @@
           "name": "meta.function.static.js",
           "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)([_$a-zA-Z][$\\w]*)\\s*(=)\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
           "end": "(?=\\s*\\{)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "entity.name.class.js" },
             "2": { "name": "keyword.operator.accessor.js" },
@@ -735,7 +735,7 @@
           "name": "meta.function-call.with-arguments.js",
           "begin": "\\s*([_$a-zA-Z][$\\w]*)\\s*(?=\\()",
           "end": "\\s*(?<=\\))",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "entity.name.function.js" }
           },
@@ -751,7 +751,7 @@
           "name": "meta.function-call.without-arguments.js",
           "begin": "\\s*([_$a-zA-Z][$\\w]*)\\s*(?=\\(\\s*\\))",
           "end": "\\s*(?=.)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "entity.name.function.js" }
           },
@@ -763,7 +763,7 @@
           "name": "meta.function-call.with-arguments.js",
           "begin": "\\s*([_$a-zA-Z][$\\w]*)\\s*(?=\\()",
           "end": "\\s*(?=.)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "entity.name.function.js" }
           },
@@ -1061,7 +1061,7 @@
           "name": "meta.function.arrow.js",
           "begin": "\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*(\\((?:(?>[^()]+)|\\g<-1>)*\\))\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "endCaptures": {
             "1": { "name": "storage.type.function.arrow.js" }
           },
@@ -1093,7 +1093,7 @@
           "name": "meta.function.arrow.js",
           "begin": "\\s*(\\b[_$a-zA-Z][$\\w]*)\\s*(=)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*(\\((?:(?>[^()]+)|\\g<-1>)*\\))\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "entity.name.function.js" },
             "2": { "name": "keyword.operator.assignment.js"},
@@ -1129,7 +1129,7 @@
           "name": "meta.prototype.function.arrow.js",
           "begin": "\\s*(\\b[A-Z][$\\w]*)?(\\.)(prototype)(\\.)([_$a-zA-Z][$\\w]*)\\s*(=)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*(\\((?:(?>[^()]+)|\\g<-1>)*\\))\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "entity.name.class.js" },
             "2": { "name": "keyword.operator.accessor.js" },
@@ -1173,7 +1173,7 @@
           "name": "meta.function.static.arrow.js",
           "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)([_$a-zA-Z][$\\w]*)\\s*(=)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*(\\((?:(?>[^()]+)|\\g<-1>)*\\))\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "entity.name.class.js" },
             "2": { "name": "keyword.operator.accessor.js" },
@@ -1218,7 +1218,7 @@
           "name": "meta.function.method.js",
           "begin": "\\s*(\\bstatic\\b)?\\s*(\\basync\\b)?\\s*(\\*?)\\s*(?<!\\.)([_$a-zA-Z][$\\w]*)\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?(\\())",
           "end": "\\s*(?=.)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "storage.modifier.js" },
             "2": { "name": "storage.type.js" },
@@ -1234,7 +1234,7 @@
           "name": "meta.accessor.js",
           "begin": "\\s*\\b(?:(static)\\s+)?(get|set)\\s+([_$a-zA-Z][$\\w]*)\\s*(?=\\()",
           "end": "\\s*(?={)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "storage.modifier.static.js" },
             "2": { "name": "storage.type.accessor.js" },
@@ -1565,7 +1565,7 @@
           "comment": "maybe an issue if a object literal is returned and the start of func block isn't on same line!",
           "begin": "(?<=\\))\\s*(:)",
           "end": "(?=.)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "punctuation.type.flowtype"}
           },
@@ -1648,7 +1648,7 @@
           "comment": "typed entity :",
           "begin": "\\s*(:)",
           "end": "(?=.)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "punctuation.type.flowtype"}
           },
@@ -1676,7 +1676,7 @@
           "comment": "call back with a form  ) => type",
           "begin": "(?<=\\))\\s*=>",
           "end": "(?=.)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "0": { "name": "storage.type.function.arrow.js" }
           },
@@ -1829,7 +1829,7 @@
       "comment": "object literal flowtype  preceded by either  : | & ? symbols",
       "begin": "(?<=:|\\||&|\\?)\\s*(\\{)",
       "end": "\\s*(\\})",
-      "applyEndPatternLast": "1",
+      "applyEndPatternLast": 1,
       "beginCaptures": {
         "1": { "name": "meta.brace.round.open.flowtype" }
       },
@@ -1892,7 +1892,7 @@
             {
               "begin": "\\s*{",
               "end": "\\s*}",
-              "applyEndPatternLast": "1",
+              "applyEndPatternLast": 1,
               "beginCaptures": {
                 "0": { "name": "meta.brace.curly.js" }
               },
@@ -1920,7 +1920,7 @@
           "comment": "find declare module and declare class defs",
           "begin": "\\s*\\b(interface)\\s+(?=[$_\\p{L}])",
           "end": "\\s*(?:(;)|\\n|(}))",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "support.type.interface.flowtype" }
           },
@@ -1981,7 +1981,7 @@
         {
           "begin": "\\s*\\b(declare)\\s+(?=(class|function|module|var))\\b",
           "end": "(?=.)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "support.type.declare.flowtype" }
           },
@@ -2003,7 +2003,7 @@
         {
           "begin": "\\s*\\b(class)\\s+",
           "end": "\\s*(})",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "storage.type.class.flowtype" }
           },
@@ -2046,7 +2046,7 @@
         {
           "begin": "\\s*\\b(function)\\s+",
           "end": "\\s*(;)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "storage.type.function.js" }
           },
@@ -2062,7 +2062,7 @@
         {
           "begin": "\\s*\\b(var)\\s+",
           "end": "\\s*(?=.)",
-          "applyEndPatternLast": "1",
+          "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": { "name": "storage.type.var.js" }
           },


### PR DESCRIPTION
It seems that atom doesn't care what the type of `applyEndPatternLast` is, so long as it's [truthy](https://github.com/atom/first-mate/commit/610d952f1ecf554594d5cb7b5740824098a4a4d5#diff-51bc0271fadf50c8255c53cc3c01fdb1R13). However, after #80, #81 and this PR, it's then possible using [AAAPackageDev](https://github.com/SublimeText/AAAPackageDev) to convert this syntax definition into a  `tmLanguage` file and have it work with Sublime out-of-the-box :smile: 

@gandm This is change is mostly just for me. It'll make it easier for me to sync changes back-and-forth between language-babel and babel-sublime.