### PR TITLE
Comments and spaces fixes

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -39,7 +39,7 @@
         { "include": "#literal-arrow-function-labels" },
         { "include": "#literal-function" },
         { "include": "#literal-arrow-function" },
-        { "include": "#literal-prototype" , "comment": " after literal-function, which includes some prototype strings"},
+        { "include": "#literal-prototype" , "comment": "after literal-function, which includes some prototype strings"},
         { "include": "#literal-regexp" , "comment": "before operators to avoid abiguities"},
         { "include": "#literal-number" },
         { "include": "#literal-quasi" },
@@ -61,7 +61,7 @@
     "literal-function-labels": {
       "patterns": [
         {
-          "comment": " e.g. play: function(arg1, arg2) {  }",
+          "comment": "e.g. play: function(arg1, arg2) { }",
           "name": "meta.function.json.js",
           "begin": "\\s*([_$a-zA-Z][$\\w]*)\\s*(:)\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(?:(\\*)\\s*)?\\s*(?=\\(|<)",
           "end": "(?=\\{)",
@@ -78,7 +78,7 @@
           ]
         },
         {
-          "comment": "e.g. 'play': function(arg1, arg2) {  }",
+          "comment": "e.g. 'play': function(arg1, arg2) { }",
           "name": "meta.function.json.js",
           "begin": "\\s*(('|\\\")(\\b[_$a-zA-Z][$\\w]*)(\\k<2>))\\s*(:)\\s*(async)?\\s+(\\bfunction\\b)\\s*(\\*\\s*)?\\s*(?=\\(|<)",
           "end": "(?=\\{)",
@@ -102,7 +102,7 @@
     "literal-arrow-function-labels": {
       "patterns": [
         {
-          "comment": "# e.g. play: async <T>(args) => { }",
+          "comment": "e.g. play: async <T>(args) => { }",
           "name": "meta.function.json.arrow.js",
           "begin": "\\s*(\\b[_$a-zA-Z][$\\w]*)\\s*(:)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*(\\((?:(?>[^()]+)|\\g<-1>)*\\))\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
@@ -120,7 +120,7 @@
           ]
         },
         {
-          "comment": "# e.g. play: arg => { }",
+          "comment": "e.g. play: arg => { }",
           "name": "meta.function.json.arrow.js",
           "begin": "\\s*(\\b[_$a-zA-Z][$\\w]*)\\s*(:)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*([_$a-zA-Z][$\\w]*)\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
@@ -138,7 +138,7 @@
           ]
         },
         {
-          "comment": "# e.g. 'play': (args) => { }",
+          "comment": "e.g. 'play': (args) => { }",
           "name": "meta.function.json.arrow.js",
           "begin": "\\s*(('|\\\")(\\b[_$a-zA-Z][$\\w]*)(\\k<2>))\\s*(:)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*(\\((?:(?>[^()]+)|\\g<-1>)*\\))\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
@@ -159,7 +159,7 @@
           ]
         },
         {
-          "comment": "# e.g. 'play': arg => { }",
+          "comment": "e.g. 'play': arg => { }",
           "name": "meta.function.json.arrow.js",
           "begin": "\\s*(('|\\\")(\\b[_$a-zA-Z][$\\w]*)(\\k<2>))\\s*(:)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*([_$a-zA-Z][$\\w]*)\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
@@ -495,7 +495,7 @@
       "patterns": [
         {
           "comment": "flowtype vars with a : to indicate type",
-          "comment": "these statements must end in a ; ",
+          "comment": "these statements must end in a ;",
           "begin": "\\s*(?<!\\.)\\b(const|let|var)\\b\\s+(?=[$_\\p{L}](?:[$\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}-]*+\\s*:))",
           "end": "\\s*\\;",
           "beginCaptures": {
@@ -510,7 +510,7 @@
         },
         {
           "comment": "flowtype objects {a,b,{z}} with a : to indicate type",
-          "comment": "these statements must end in a ; ",
+          "comment": "these statements must end in a ;",
           "begin": "\\s*(?<!\\.)\\b(const|let|var)\\b\\s+(?=(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})\\s*:)",
           "end": "\\s*\\;",
           "beginCaptures": {
@@ -525,7 +525,7 @@
         },
         {
           "comment": "flowtype arrays [a,[b,c]] with a : to indicate type",
-          "comment": "these statements must end in a ; ",
+          "comment": "these statements must end in a ;",
           "begin": "\\s*(?<!\\.)\\b(const|let|var)\\b\\s+(?=(\\[(?:(?>[^\\[\\]]+)|\\g<-1>)*\\])\\s*:)",
           "end": "\\s*\\;",
           "beginCaptures": {
@@ -548,7 +548,7 @@
     "literal-function": {
       "patterns": [
         {
-          "comment": "e.g. function play<T>(arg1, arg2) {  }",
+          "comment": "e.g. function play<T>(arg1, arg2) { }",
           "name": "meta.function.js",
           "begin": "\\s*(?:\\b(async)\\b\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
           "end": "(?=\\s*\\{)",
@@ -564,7 +564,7 @@
           ]
         },
         {
-          "comment": "e.g. play = function(arg1, arg2) {  }",
+          "comment": "e.g. play = function(arg1, arg2) { }",
           "name": "meta.function.js",
           "begin": "\\s*(\\b[_$a-zA-Z][$\\w]*)\\s*(=)\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
           "end": "(?=\\s*\\{)",
@@ -582,7 +582,7 @@
           ]
         },
         {
-          "comment": "e.g. Sound.prototype.play = function(arg1, arg2) {  }",
+          "comment": "e.g. Sound.prototype.play = function(arg1, arg2) { }",
           "name": "meta.prototype.function.js",
           "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)(prototype)(\\.)([_$a-zA-Z][$\\w]*)\\s*(=)\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
           "end": "(?=\\s*\\{)",
@@ -604,7 +604,7 @@
           ]
         },
         {
-          "comment": "e.g. Sound.play = function(arg1, arg2) {  }",
+          "comment": "e.g. Sound.play = function(arg1, arg2) { }",
           "name": "meta.function.static.js",
           "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)([_$a-zA-Z][$\\w]*)\\s*(=)\\s*(?:(async)\\s+)?\\s*(\\bfunction\\b)\\s*(\\*?)\\s*([_$a-zA-Z][$\\w]*)?\\s*(?=\\(|<)",
           "end": "(?=\\s*\\{)",
@@ -717,8 +717,8 @@
       ]
     },
     "ternary-function-call": {
-      "comment": "special pattern of function calls that doesn't call",
-      "comment": "#flowtype as this assumes the : following a ) : is a return type",
+      "comment": "special pattern of function calls that doesn't call #flowtype",
+      "comment": "as this assumes the : following a ) : is a return type",
       "patterns": [
         {
           "name": "meta.function-call.without-arguments.js",
@@ -1073,7 +1073,7 @@
           ]
         },
         {
-          "comment": "# e.g. arg => { }",
+          "comment": "e.g. arg => { }",
           "name": "meta.function.arrow.js",
           "begin": "\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*([_$a-zA-Z][$\\w]*)\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
@@ -1089,7 +1089,7 @@
           ]
         },
         {
-          "comment": "# e.g. play = (args) => { }",
+          "comment": "e.g. play = (args) => { }",
           "name": "meta.function.arrow.js",
           "begin": "\\s*(\\b[_$a-zA-Z][$\\w]*)\\s*(=)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*(\\((?:(?>[^()]+)|\\g<-1>)*\\))\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
@@ -1107,7 +1107,7 @@
           ]
         },
         {
-          "comment": "# e.g. play = arg => { }",
+          "comment": "e.g. play = arg => { }",
           "name": "meta.function.arrow.js",
           "begin": "\\s*(\\b[_$a-zA-Z][$\\w]*)\\s*(=)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*([_$a-zA-Z][$\\w]*)\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
@@ -1147,7 +1147,7 @@
           ]
         },
         {
-          "comment": "# e.g. Sound.prototype.play = arg => { }",
+          "comment": "e.g. Sound.prototype.play = arg => { }",
           "name": "meta.prototype.function.arrow.js",
           "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)(prototype)(\\.)([_$a-zA-Z][$\\w]*)\\s*(=)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*([_$a-zA-Z][$\\w]*)\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
@@ -1190,7 +1190,7 @@
           ]
         },
         {
-          "comment": "# e.g. Sound.play = arg => { }",
+          "comment": "e.g. Sound.play = arg => { }",
           "name": "meta.function.static.arrow.js",
           "begin": "\\s*(\\b_?[A-Z][$\\w]*)?(\\.)([_$a-zA-Z][$\\w]*)\\s*(=)\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*([_$a-zA-Z][$\\w]*)\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
@@ -1214,7 +1214,7 @@
     "literal-method": {
       "patterns": [
         {
-          "comment": " e.g. play<T,T>(arg1, arg2): Type<T> {  }",
+          "comment": "e.g. play<T,T>(arg1, arg2): Type<T> { }",
           "name": "meta.function.method.js",
           "begin": "\\s*(\\bstatic\\b)?\\s*(\\basync\\b)?\\s*(\\*?)\\s*(?<!\\.)([_$a-zA-Z][$\\w]*)\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?(\\())",
           "end": "\\s*(?=.)",
@@ -1230,7 +1230,7 @@
           ]
         },
         {
-          "comment": " getter/setter ",
+          "comment": "getter/setter",
           "name": "meta.accessor.js",
           "begin": "\\s*\\b(?:(static)\\s+)?(get|set)\\s+([_$a-zA-Z][$\\w]*)\\s*(?=\\()",
           "end": "\\s*(?={)",

--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -17,9 +17,9 @@
   "repository": {
     "core": {
       "patterns": [
-        { "include": "#flowtype-declare"},
-        { "include": "#flowtype-type-aliases"},
-        { "include": "#flowtype-interface"},
+        { "include": "#flowtype-declare" },
+        { "include": "#flowtype-type-aliases" },
+        { "include": "#flowtype-interface" },
         { "include": "#literal-function-labels" },
         { "include": "#literal-arrow-function-labels" },
         { "include": "#literal-labels" },
@@ -39,14 +39,14 @@
         { "include": "#literal-arrow-function-labels" },
         { "include": "#literal-function" },
         { "include": "#literal-arrow-function" },
-        { "include": "#literal-prototype" , "comment": "after literal-function, which includes some prototype strings"},
-        { "include": "#literal-regexp" , "comment": "before operators to avoid abiguities"},
+        { "include": "#literal-prototype", "comment": "after literal-function, which includes some prototype strings" },
+        { "include": "#literal-regexp", "comment": "before operators to avoid abiguities" },
         { "include": "#literal-number" },
         { "include": "#literal-quasi" },
         { "include": "#literal-string" },
         { "include": "#literal-language-constant" },
         { "include": "#literal-language-variable" },
-        { "include": "#literal-method"},
+        { "include": "#literal-method" },
         { "include": "#literal-module" },
         { "include": "#literal-class" },
         { "include": "#literal-constructor" },
@@ -133,7 +133,7 @@
             "1": { "name": "storage.type.function.arrow.js" }
           },
           "patterns": [
-            { "include": "#flowtype-polymorphs"},
+            { "include": "#flowtype-polymorphs" },
             { "include": "#flowtype-variable" }
           ]
         },
@@ -175,7 +175,7 @@
             "1": { "name": "storage.type.function.arrow.js" }
           },
           "patterns": [
-            { "include": "#flowtype-polymorphs"},
+            { "include": "#flowtype-polymorphs" },
             { "include": "#flowtype-variable" }
           ]
         }
@@ -499,13 +499,13 @@
           "begin": "\\s*(?<!\\.)\\b(const|let|var)\\b\\s+(?=[$_\\p{L}](?:[$\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}-]*+\\s*:))",
           "end": "\\s*\\;",
           "beginCaptures": {
-            "1": { "name": "storage.type.js"}
+            "1": { "name": "storage.type.js" }
           },
           "endCaptures": {
-            "0": { "name": "punctuationterminator.statement.js"}
+            "0": { "name": "punctuationterminator.statement.js" }
           },
           "patterns": [
-            { "include": "#flowtype-variable"}
+            { "include": "#flowtype-variable" }
           ]
         },
         {
@@ -514,13 +514,13 @@
           "begin": "\\s*(?<!\\.)\\b(const|let|var)\\b\\s+(?=(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})\\s*:)",
           "end": "\\s*\\;",
           "beginCaptures": {
-            "1": { "name": "storage.type.js"}
+            "1": { "name": "storage.type.js" }
           },
           "endCaptures": {
-            "0": { "name": "punctuationterminator.statement.js"}
+            "0": { "name": "punctuationterminator.statement.js" }
           },
           "patterns": [
-            { "include": "#flowtype-destruct-lhs"}
+            { "include": "#flowtype-destruct-lhs" }
           ]
         },
         {
@@ -529,13 +529,13 @@
           "begin": "\\s*(?<!\\.)\\b(const|let|var)\\b\\s+(?=(\\[(?:(?>[^\\[\\]]+)|\\g<-1>)*\\])\\s*:)",
           "end": "\\s*\\;",
           "beginCaptures": {
-            "1": { "name": "storage.type.js"}
+            "1": { "name": "storage.type.js" }
           },
           "endCaptures": {
-            "0": { "name": "punctuationterminator.statement.js"}
+            "0": { "name": "punctuationterminator.statement.js" }
           },
           "patterns": [
-            { "include": "#flowtype-destruct-lhs"}
+            { "include": "#flowtype-destruct-lhs" }
           ]
         },
         {
@@ -696,14 +696,14 @@
           "begin": "\\s*(\\?)",
           "end": "\\s*(:)",
           "beginCaptures": {
-            "1": { "name": "keyword.operator.ternary.js"}
+            "1": { "name": "keyword.operator.ternary.js" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.operator.ternary.js"}
+            "1": { "name": "keyword.operator.ternary.js" }
           },
           "patterns": [
-            { "include": "#ternary-function-call"},
-            { "include": "#expression"}
+            { "include": "#ternary-function-call" },
+            { "include": "#expression" }
           ]
         },
         {
@@ -899,8 +899,8 @@
                 "1": { "name": "storage.type.extends.js" }
               }
             },
-            { "include": "#flowtype-class-name"},
-            { "include": "#flowtype-polymorphs"},
+            { "include": "#flowtype-class-name" },
+            { "include": "#flowtype-polymorphs" },
             {
               "begin": "\\s*{",
               "end": "\\s*(?=})",
@@ -909,18 +909,18 @@
                 "0": { "name": "punctuation.section.class.begin.js" }
               },
               "patterns": [
-                { "match":"\\s*\\b(?<!\\.)static\\b(?!\\.)",
+                { "match": "\\s*\\b(?<!\\.)static\\b(?!\\.)",
                   "name": "storage.modifier.js"
                 },
                 { "include": "#brackets" },
                 { "include": "#es7-decorators" },
                 { "include": "#comments" },
-                { "include": "#literal-method"},
+                { "include": "#literal-method" },
                 { "include": "#flowtype-variable" }
 
               ]
             },
-            { "include": "#expression"}
+            { "include": "#expression" }
           ]
         }
       ]
@@ -1078,13 +1078,13 @@
           "begin": "\\s*(\\basync\\b)?\\s*(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*([_$a-zA-Z][$\\w]*)\\s*(?:\\s*(:|\\|)(\\s*[$_a-zA-Z0-9]+(<(?:(?>[^<>]+)|\\g<-1>)*>)?|\\s*(\\{(?:(?>[^{}]+)|\\g<-1>)*\\})|\\s*(\\s*([\"']).*?\\k<-1>(?<!\\\\.))|\\s*[x0-9A-Fa-f]+))*\\s*=>)",
           "end": "\\s*(=>)",
           "beginCaptures": {
-            "1": {"name": "storage.type.js"}
+            "1": { "name": "storage.type.js" }
           },
           "endCaptures": {
             "1": { "name": "storage.type.function.arrow.js" }
           },
           "patterns": [
-            { "include": "#flowtype-polymorphs"},
+            { "include": "#flowtype-polymorphs" },
             { "include": "#flowtype-variable" }
           ]
         },
@@ -1096,7 +1096,7 @@
           "applyEndPatternLast": "1",
           "beginCaptures": {
             "1": { "name": "entity.name.function.js" },
-            "2": { "name": "keyword.operator.assignment.js"},
+            "2": { "name": "keyword.operator.assignment.js" },
             "3": { "name": "storage.type.js" }
           },
           "endCaptures": {
@@ -1120,7 +1120,7 @@
             "1": { "name": "storage.type.function.arrow.js" }
           },
           "patterns": [
-            { "include": "#flowtype-polymorphs"},
+            { "include": "#flowtype-polymorphs" },
             { "include": "#flowtype-variable" }
           ]
         },
@@ -1164,7 +1164,7 @@
             "1": { "name": "storage.type.function.arrow.js" }
           },
           "patterns": [
-            { "include": "#flowtype-polymorphs"},
+            { "include": "#flowtype-polymorphs" },
             { "include": "#flowtype-variable" }
           ]
         },
@@ -1205,7 +1205,7 @@
             "1": { "name": "storage.type.function.arrow.js" }
           },
           "patterns": [
-            { "include": "#flowtype-polymorphs"},
+            { "include": "#flowtype-polymorphs" },
             { "include": "#flowtype-variable" }
           ]
         }
@@ -1385,8 +1385,8 @@
           "name"  : "tag.decorator.js",
           "match": "\\s*(?!@)(@)([_$a-zA-Z][$\\w]*)\\b",
           "captures": {
-            "1": {"name": "punctuation.definition.tag.js"},
-            "2": {"name": "entity.name.tag.js"}
+            "1": { "name": "punctuation.definition.tag.js" },
+            "2": { "name": "entity.name.tag.js" }
           }
         }
       ]
@@ -1422,7 +1422,7 @@
           },
           "patterns": [
             { "include": "#jsx-tag-termination" },
-            { "include": "#jsx-tag-attributes"}
+            { "include": "#jsx-tag-attributes" }
           ]
         }
       ]
@@ -1440,7 +1440,7 @@
           "patterns": [
             { "include": "#jsx-evaluated-code" },
             { "include": "#jsx-entities" },
-            { "include": "#jsx-tag-element-name"}
+            { "include": "#jsx-tag-element-name" }
           ]
         }
       ]
@@ -1452,8 +1452,8 @@
         { "include": "#jsx-string-double-quoted" },
         { "include": "#jsx-string-single-quoted" },
         { "include": "#jsx-evaluated-code" },
-        { "include": "#jsx-tag-element-name"},
-        { "include": "#comments"}
+        { "include": "#jsx-tag-element-name" },
+        { "include": "#comments" }
       ]
     },
     "jsx-spread-attribute": {
@@ -1527,7 +1527,7 @@
       "patterns": [
         { "include": "#jsx-string-double-quoted" },
         { "include": "#jsx-string-single-quoted" },
-        { "include": "#jsx-spread-attribute"},
+        { "include": "#jsx-spread-attribute" },
         { "include": "#expression" }
       ]
     },
@@ -1538,9 +1538,9 @@
           "match": "(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)",
           "captures": {
             "0": { "name": "constant.character.entity.jsx" },
-            "1": { "name": "punctuation.definition.entity.jsx"},
-            "2": { "name": "entity.name.tag.html.jsx"},
-            "3": { "name": "punctuation.definition.entity.jsx"}
+            "1": { "name": "punctuation.definition.entity.jsx" },
+            "2": { "name": "entity.name.tag.html.jsx" },
+            "3": { "name": "punctuation.definition.entity.jsx" }
           }
         },
         {
@@ -1552,9 +1552,9 @@
     },
     "flowtype": {
       "patterns": [
-        { "include": "#flowtype-polymorphs"},
+        { "include": "#flowtype-polymorphs" },
         { "include": "#flowtype-bracketed-parameters" },
-        { "include": "#flowtype-return"}
+        { "include": "#flowtype-return" }
       ]
     },
     "flowtype-return": {
@@ -1567,10 +1567,10 @@
           "end": "(?=.)",
           "applyEndPatternLast": "1",
           "beginCaptures": {
-            "1": { "name": "punctuation.type.flowtype"}
+            "1": { "name": "punctuation.type.flowtype" }
           },
           "patterns": [
-            { "include": "#flowtype-parse-types"}
+            { "include": "#flowtype-parse-types" }
           ]
         }
       ]
@@ -1597,14 +1597,14 @@
           "begin": "\\s*{",
           "end": "\\s*}",
           "patterns": [
-            { "include": "#flowtype-destruct-lhs"}
+            { "include": "#flowtype-destruct-lhs" }
           ]
         },
         {
           "begin": "\\s*\\[",
           "end": "\\s*\\]",
           "patterns": [
-            { "include": "#flowtype-destruct-lhs"}
+            { "include": "#flowtype-destruct-lhs" }
           ]
         },
         {
@@ -1612,8 +1612,8 @@
           "match": "\\s*((['\\\"]).*?\\k<-1>(?<!\\\\.))\\s*(:)\\s*(([$_\\p{L}](?:[$.\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}])*+))",
           "captures": {
             "1": { "name": "string.quoted.js" },
-            "3": { "name": "punctuation"},
-            "4": { "name": "variable.other.property.js"}
+            "3": { "name": "punctuation" },
+            "4": { "name": "variable.other.property.js" }
           }
         },
         {
@@ -1621,8 +1621,8 @@
           "match": "\\s*([$_\\p{L}](?:[$.\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}])*+)\\s*(:)\\s*(([$_\\p{L}](?:[$.\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}])*+))",
           "captures": {
             "1": { "name": "string.unquoted.js" },
-            "2": { "name": "punctuation"},
-            "3": { "name": "variable.other.property.js"}
+            "2": { "name": "punctuation" },
+            "3": { "name": "variable.other.property.js" }
           }
         },
         {
@@ -1633,8 +1633,8 @@
             "2": { "name": "variable.other.property.js" }
           }
         },
-        { "match": "\\s*,"},
-        { "include": "#flowtype-vars-and-props"}
+        { "match": "\\s*," },
+        { "include": "#flowtype-vars-and-props" }
       ]
     },
     "flowtype-vars-and-props": {
@@ -1650,10 +1650,10 @@
           "end": "(?=.)",
           "applyEndPatternLast": "1",
           "beginCaptures": {
-            "1": { "name": "punctuation.type.flowtype"}
+            "1": { "name": "punctuation.type.flowtype" }
           },
           "patterns": [
-            { "include": "#flowtype-parse-types"}
+            { "include": "#flowtype-parse-types" }
           ]
         },
         {
@@ -1664,9 +1664,9 @@
           "comment": "An Iterator prefix?",
           "match": "\\s*@@"
         },
-        { "include": "#flowtype-bracketed-parameters"},
-        { "include": "#flowtype-parse-operators"},
-        { "include": "#flowtype-parse-array"},
+        { "include": "#flowtype-bracketed-parameters" },
+        { "include": "#flowtype-parse-operators" },
+        { "include": "#flowtype-parse-array" },
         { "include": "#expression" }
       ]
     },
@@ -1753,12 +1753,12 @@
           },
           { "include": "#literal-string" },
           { "include": "#literal-number" },
-          { "include": "#flowtype-polymorphs"},
+          { "include": "#flowtype-polymorphs" },
           { "include": "#flowtype-bracketed-parameters" },
           { "include": "#flowtype-parse-objects" },
-          { "include": "#flowtype-parse-operators"},
-          { "include": "#flowtype-parse-array"},
-          { "include": "#comments"}
+          { "include": "#flowtype-parse-operators" },
+          { "include": "#flowtype-parse-array" },
+          { "include": "#comments" }
         ]
     },
     "flowtype-bracketed-parameters": {
@@ -1774,7 +1774,7 @@
             "1": { "name": "punctuation.definition.parameters.end.js" }
           },
           "patterns": [
-            { "include": "#flowtype-variable"}
+            { "include": "#flowtype-variable" }
           ]
         }
       ]
@@ -1788,10 +1788,10 @@
           "end": "\\s*(>)",
           "beginCaptures": {
             "1": { "name": "support.type.builtin.flowtype" },
-            "2": { "name": "punctuation.flowtype"}
+            "2": { "name": "punctuation.flowtype" }
           },
           "endCaptures"     : {
-            "1": { "name": "punctuation.flowtype"}
+            "1": { "name": "punctuation.flowtype" }
           },
           "patterns": [
             { "match": "\\s*,",
@@ -1800,7 +1800,7 @@
             { "match": "\\s*:",
               "name": "punctuation.type.separator.flowtype"
             },
-            { "include": "#flowtype-parse-types"}
+            { "include": "#flowtype-parse-types" }
           ]
         },
         {
@@ -1808,10 +1808,10 @@
           "begin": "\\s*(<)(?!<)",
           "end": "\\s*(>)",
           "beginCaptures": {
-            "1": { "name": "punctutation.flowtype"}
+            "1": { "name": "punctutation.flowtype" }
           },
           "endCaptures": {
-            "1": { "name": "punctutation.flowtype"}
+            "1": { "name": "punctutation.flowtype" }
           },
           "patterns": [
             { "match": "\\s*,",
@@ -1820,7 +1820,7 @@
             { "match": "\\s*:",
               "name": "punctuation.type.separator.flowtype"
             },
-            { "include": "#flowtype-parse-types"}
+            { "include": "#flowtype-parse-types" }
           ]
         }
       ]
@@ -1837,7 +1837,7 @@
         "1": { "name": "meta.brace.round.close.flowtype" }
       },
       "patterns": [
-        { "include": "#flowtype-object-property"}
+        { "include": "#flowtype-object-property" }
       ]
     },
     "flowtype-object-property": {
@@ -1864,7 +1864,7 @@
         "1": { "name": "meta.brace.square.end.flowtype" }
       },
       "patterns": [
-        { "include": "#flowtype-variable"}
+        { "include": "#flowtype-variable" }
       ]
     },
     "flowtype-type-aliases": {
@@ -1874,7 +1874,7 @@
           "match": "\\s*(?<!\\.)\\b(import)\\b\\s*(type)\\b",
           "captures": {
             "1": { "name":  "keyword.control.module.js" },
-            "2": { "name":  "support.type.type.flowtype"}
+            "2": { "name":  "support.type.type.flowtype" }
           }
         },
         {
@@ -1885,7 +1885,7 @@
             "1": { "name": "support.type.type.flowtype" }
           },
           "endCaptures": {
-            "1": { "name": "punctuation.object.end.flowtype"}
+            "1": { "name": "punctuation.object.end.flowtype" }
           },
           "patterns": [
             { "match": "\\s*=" },
@@ -1901,15 +1901,15 @@
               },
               "patterns": [
                 { "include": "#flowtype" },
-                { "include": "#flowtype-variable"},
-                { "include": "#comments"},
-                { "include": "#flowtype-function-name"}
+                { "include": "#flowtype-variable" },
+                { "include": "#comments" },
+                { "include": "#flowtype-function-name" }
               ]
             },
             { "include": "#flowtype" },
-            { "include": "#flowtype-parse-types"},
-            { "include": "#comments"},
-            { "include": "#flowtype-function-name"}
+            { "include": "#flowtype-parse-types" },
+            { "include": "#comments" },
+            { "include": "#flowtype-function-name" }
           ]
         }
       ]
@@ -1929,15 +1929,15 @@
             "2": { "name": "punctuation.section.class.end.js" }
           },
           "patterns": [
-            { "include": "#comments"},
+            { "include": "#comments" },
             {
               "match": "\\s*\\b(extends)\\b\\s*",
               "captures": {
                 "1": { "name": "storage.type.extends.flowtype" }
               }
             },
-            { "include": "#flowtype"},
-            { "include": "#flowtype-interface-name"},
+            { "include": "#flowtype" },
+            { "include": "#flowtype-interface-name" },
             {
               "begin": "\\s*{",
               "end": "\\s*(?=})",
@@ -1946,13 +1946,13 @@
                 "0": { "name": "punctuation.section.class.begin.js" }
               },
               "patterns": [
-                { "match":"\\s*\\b(?<!\\.)static\\b(?!\\.)",
+                { "match": "\\s*\\b(?<!\\.)static\\b(?!\\.)",
                   "name": "storage.modifier.js"
                 },
-                { "include": "#flowtype"},
+                { "include": "#flowtype" },
                 { "include": "#flowtype-variable" },
-                { "include": "#comments"},
-                { "include": "#flowtype-function-name"}
+                { "include": "#comments" },
+                { "include": "#flowtype-function-name" }
               ]
             }
           ]
@@ -1986,10 +1986,10 @@
             "1": { "name": "support.type.declare.flowtype" }
           },
           "patterns": [
-            { "include": "#flowtype-declare-classes"},
-            { "include": "#flowtype-declare-modules"},
-            { "include": "#flowtype-declare-function"},
-            { "include": "#flowtype-declare-vars"}
+            { "include": "#flowtype-declare-classes" },
+            { "include": "#flowtype-declare-modules" },
+            { "include": "#flowtype-declare-function" },
+            { "include": "#flowtype-declare-vars" }
           ]
         }
       ]
@@ -2025,18 +2025,18 @@
                 "0": { "name": "punctuation.section.class.begin.js" }
               },
               "patterns": [
-                { "match":"\\s*\\b(?<!\\.)static\\b(?!\\.)",
+                { "match": "\\s*\\b(?<!\\.)static\\b(?!\\.)",
                   "name": "storage.modifier.js"
                 },
-                { "include": "#literal-method"},
-                { "include": "#flowtype"},
-                { "include": "#flowtype-variable"},
-                { "include": "#comments"},
-                { "include": "#flowtype-function-name"}
+                { "include": "#literal-method" },
+                { "include": "#flowtype" },
+                { "include": "#flowtype-variable" },
+                { "include": "#comments" },
+                { "include": "#flowtype-function-name" }
               ]
             },
-            { "include": "#flowtype-class-name"},
-            { "include": "#flowtype-polymorphs"}
+            { "include": "#flowtype-class-name" },
+            { "include": "#flowtype-polymorphs" }
           ]
         }
       ]
@@ -2051,8 +2051,8 @@
             "1": { "name": "storage.type.function.js" }
           },
           "patterns": [
-            { "include": "#flowtype"},
-            { "include": "#flowtype-function-name"}
+            { "include": "#flowtype" },
+            { "include": "#flowtype-function-name" }
           ]
         }
       ]
@@ -2067,7 +2067,7 @@
             "1": { "name": "storage.type.var.js" }
           },
           "patterns": [
-            { "include": "#flowtype-variable"}
+            { "include": "#flowtype-variable" }
           ]
         }
       ]
@@ -2078,7 +2078,7 @@
           "begin": "\\s*:",
           "end": "(?=\\s*\\))",
           "patterns": [
-            { "include": "#flowtype-parse-types"}
+            { "include": "#flowtype-parse-types" }
           ]
         }
       ]


### PR DESCRIPTION
The spacing fixes are so subsequent PRs are less noisy. The comments fixes are (selfishly) so when I convert this to YAML, they don't look super weird (e.g. with a double `#`).