### PR TITLE
Here is how things would work if this were its own package.

### DIFF
--- a/lib/babel-transpiler.coffee
+++ b/lib/babel-transpiler.coffee
@@ -1,21 +1,2 @@
-{CompositeDisposable} = require 'atom'
-defaultConfig = require './config'
-{Transpiler} = require './transpiler'
-
-module.exports = 
-  config: defaultConfig
-
-  activate: (state) ->
-    if not @transpiler?
-      @transpiler = new Transpiler
-    # track any file save ( buffer save) events and transpile if babel
-    @disposable = new CompositeDisposable
-    @disposable.add  atom.workspace.observeTextEditors (textEditor) =>
-      @disposable.add textEditor.onDidSave (event) =>
-        grammar = textEditor.getGrammar()
-        return if grammar.packageName isnt 'language-babel'
-        @transpiler.transpile(event.path, textEditor)
-
-  deactivate: ->
-    if @disposable?
-      @disposable.dispose()
+module.exports =
+  config: require './config'


### PR DESCRIPTION
On my machine (with all of Nuclide installed), here is what timecop looks like before this change:

![screen shot 2015-09-23 at 9 37 35 am](https://cloud.githubusercontent.com/assets/655869/10051598/32cd9f90-61d7-11e5-9557-cf5b54d69e2f.png)

And here is what timecop looks like after this change:

![screen shot 2015-09-23 at 9 39 32 am](https://cloud.githubusercontent.com/assets/655869/10051604/360ce512-61d7-11e5-8826-560e4ef6768d.png)

There is a dramatic difference in load time if this could be split out into a package that were only the grammar.

Without even testing, I'm 99% sure the reason why `line-ending-selector` is in that list is because of this line:

https://github.com/atom/line-ending-selector/blob/54c23121ae8ba18ba3992a4ccceda44b750b6fe8/lib/main.js#L3

In Nuclide, you can see that we don't allow *any* of our packages to depend on `lodash`, `q`, or `underscore` because we have found that they have a serious negative effect on load times:

https://github.com/facebook/nuclide/blob/e961c4d3461c3abc35a6f8ccaf3f6e959b622f1e/scripts/lib/package_linter.py#L21-L27