### PR TITLE
Fix dollar variable scopes

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -1377,10 +1377,7 @@
         {
           "comment": "e.g. dollar vars",
           "name": "variable.other.dollar.js",
-          "match": "\\s*(\\$)([$\\w]+)?",
-          "captures": {
-            "1": { "name": "punctuation.dollar.js" }
-          }
+          "match": "\\s*\\$[$\\w]*"
         },
         {
           "comment": "e.g. Class.property",

--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -1377,9 +1377,9 @@
         {
           "comment": "e.g. dollar vars",
           "name": "variable.other.dollar.js",
-          "match": "\\s*(\\$)[$\\w]+",
+          "match": "\\s*(\\$)([$\\w]+)?",
           "captures": {
-            "0": { "name": "punctuation.dollar.js" }
+            "1": { "name": "punctuation.dollar.js" }
           }
         },
         {


### PR DESCRIPTION
Currently entire variables starting with `$` are receiving the scope `punctuation.dollar.js`.

Anyway, I made it so that `$` is the only part that gets the `punctuation.dollar.js` scope, and the remainder continues to get `variable.other.dollar.js`.

From
```html
<span class="variable other dollar js">
	<span class="punctuation dollar js">$variable</span>
</span>
<span class="variable other dollar js">
	<span class="punctuation dollar js">$</span>
</span>
```

To
```html
<span class="variable other dollar js">
	<span class="punctuation dollar js">$</span>variable
</span>
<span class="variable other dollar js">
	<span class="punctuation dollar js">$</span>
</span>
```

Up to you @gandm how want it to be but I'd suggest removing `punctuation.dollar.js` completely as `variable.other.dollar.js` is enough and the `$` sign isn't actually punctuation.