### PR TITLE
Add "es" to allowed fileTypes

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -7,6 +7,7 @@
   "fileTypes": [
     "js",
     "es6",
+    "es",
     "babel",
     "jsx",
     "flow"


### PR DESCRIPTION
Hi! It would be nice to recognize `.es` files with language-babel. Babel is [already supporting this extension](https://babeljs.io/docs/usage/require/#usage), and github [just merged](https://github.com/github/linguist/pull/2920) a PR to highlight it as javascript.