### PR TITLE
Remove "re" filetype from Regex syntax

### DIFF
--- a/grammars/Babel Regex.json
+++ b/grammars/Babel Regex.json
@@ -1,9 +1,7 @@
 {
   "name": "Regular Expressions (Babel)",
   "scopeName": "source.regexp.babel",
-  "fileTypes": [
-    "re"
-  ],
+  "fileTypes": [],
   "patterns": [
     { "include": "#anchor"},
     { "include": "#backref"},


### PR DESCRIPTION
Since Atom doesn't seem to have a way to manage priorities, I'm suggesting to remove the filetype here since it conflicts with Facebook's [Reason language](https://github.com/facebook/reason) and I don't think people actually write files just containing a regex.

Would fix facebook/reason#234.