### PR TITLE
add support for function-bind syntax proposal

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -701,6 +701,7 @@
     },
     "literal-operators": {
       "patterns": [
+        { "include": "#es7-function-bind" },
         {
           "name": "keyword.operator.js",
           "match": "\\s*+(?<!\\.)\\b(delete|in|instanceof|new|of|typeof|void|with)\\b"
@@ -1616,6 +1617,17 @@
             "1": { "name": "punctuation.definition.tag.js" },
             "2": { "name": "entity.name.tag.js" }
           }
+        }
+      ]
+    },
+    "es7-function-bind": {
+      "patterns": [
+        {
+          "comment": "https://github.com/zenparsing/es-function-bind#examples",
+          "match": "\\s*(::)",
+          "captures": {
+             "1": { "name": "keyword.operator.accessor.js" }
+           }
         }
       ]
     },

--- a/spec/fixtures/grammar/misc.js
+++ b/spec/fixtures/grammar/misc.js
@@ -2,7 +2,7 @@
 
 // class fields, statics and methods
 class SomeClass {
-  myProperty: string = 'some value'           
+  myProperty: string = 'some value'
 //^^^^^^^^^^^ ^^^^^^ ^ ^^^^^ ^^^^^^             meta.class.body.js
 //^^^^^^^^^^                                    variable.other.readwrite.js
 //          ^                                   punctuation.type.flowtype
@@ -158,3 +158,33 @@ type $JSXIntrinsics = {
 //^^^^  meta.tag.jsx
 //   ^  punctuation.definition.tag.jsx
 //^^^   entity.name.tag.close.jsx
+
+// Some snippets from function-bind syntax proposal
+
+getPlayers()
+//^^^^^^^^^^  meta.function-call.without-arguments.js
+//^^^^^^^^    entity.name.function.js
+//        ^^  meta.brace.round.js
+  ::map(x => x.character());
+//^^          ^               keyword.operator.accessor.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^   meta.function-call.with-arguments.js
+//  ^^^        ^^^^^^^^^      entity.name.function.js
+//     ^                  ^   meta.brace.round.js
+//      ^^^^                  meta.function.arrow.js
+//      ^                     variable.other.readwrite.js
+//        ^^                  storage.type.function.arrow.js
+//           ^                variable.other.object.js
+//             ^^^^^^^^^^^    meta.function-call.method.without-arguments
+//                      ^^    meta.group.braces.round.function.arguments.js
+//                         ^  punctuation.terminator.statement.js
+
+Promise.resolve(123).then(::console.log);
+//^^^^^                                    support.class.builtin.js
+//     ^            ^     ^^               keyword.operator.accessor.js
+//      ^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^   meta.function-call.method.with-arguments.js
+//      ^^^^^^^      ^^^^                  entity.name.function.js
+//             ^   ^     ^             ^   meta.brace.round.js
+//              ^^^                        constant.numeric.js
+//                          ^^^^^^^        support.type.object.console.js
+//                                  ^^^    support.function.console.js
+//                                      ^  punctuation.terminator.statement.js


### PR DESCRIPTION
Babel has supported function-bind syntax for a long time, so it would be nice to highlight this syntax in atom.

Please let me know if you found something to fix.

## changes

- modify label syntax (`foo: bar`) match strings to ignore double colon (`::`)

- add function-bind syntax token as a literal-operator