### PR TITLE
Support highlighting in flow comments

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -428,6 +428,35 @@
     },
     "comments": {
       "patterns": [
+        {
+          "begin": "\\s*+(/\\*)(::)",
+          "end": "\\s*(\\*/)",
+          "beginCaptures": {
+            "1": { "name": "punctuation.definition.comment.js" },
+            "2": { "name": "punctuation.type.flowtype" }
+          },
+          "endCaptures": {
+            "1": { "name": "punctuation.definition.comment.js" }
+          },
+          "patterns": [
+            { "include": "$self" }
+          ]
+        },
+        {
+          "begin": "\\s*+(/\\*)(:)",
+          "end": "\\s*(\\*/)",
+          "beginCaptures": {
+            "1": { "name": "comment.block.js" },
+            "2": { "name": "punctuation.type.flowtype" }
+          },
+          "endCaptures": {
+            "1": { "name": "punctuation.definition.comment.js" }
+          },
+          "patterns": [
+            { "include": "#flowtype-parse-types" },
+            { "include": "#flowtype-variable" }
+          ]
+        },
         { "include": "#special-comments-conditional-compilation" },
         {
           "name": "comment.block.documentation.js",


### PR DESCRIPTION
This PR adds support for highlighting inside [flow comments](https://flowtype.org/blog/2015/02/20/Flow-Comments.html). Example:

![flow-comments-opt](https://cloud.githubusercontent.com/assets/151197/16569278/c8f4bd8c-41f1-11e6-923e-35b4bad477dc.png)
