### PR TITLE
Fix closing quotes marks in import/export.

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -1548,7 +1548,7 @@
         "1": { "name": "keyword.control.module.js" },
         "3": { "name": "punctuation.definition.string.begin.js" },
         "4": { "name": "string.quoted.module.js" },
-        "5": { "name": "punctuation.definition.string.begin.js" }
+        "5": { "name": "punctuation.definition.string.end.js" }
       },
       "patterns": [
         {
@@ -1594,7 +1594,7 @@
             "1": { "name": "keyword.control.module.js" },
             "3": { "name": "punctuation.definition.string.begin.js" },
             "4": { "name": "string.quoted.module.js" },
-            "5": { "name": "punctuation.definition.string.begin.js" }
+            "5": { "name": "punctuation.definition.string.end.js" }
           },
           "patterns": [
             {

--- a/spec/fixtures/grammar/babel-sublime/flow.js
+++ b/spec/fixtures/grammar/babel-sublime/flow.js
@@ -1130,7 +1130,8 @@ import type {ClassFoo4, ClassFoo5} from "./ExportCJSNamed_Class";
 //          ^                    ^                                 meta.brace.curly.js
 //           ^^^^^^^^^  ^^^^^^^^^                                  variable.other.readwrite.js
 //                    ^                                            meta.delimiter.comma.js
-//                                      ^                      ^   punctuation.definition.string.begin.js
+//                                      ^                          punctuation.definition.string.begin.js
+//                                                             ^   punctuation.definition.string.end.js
 //                                       ^^^^^^^^^^^^^^^^^^^^^^    string.quoted.module.js
 //                                                              ^  punctuation.terminator.statement.js
 import typeof {ClassFoo4, ClassFoo5} from "./ExportCJSNamed_Class";
@@ -1141,7 +1142,8 @@ import typeof {ClassFoo4, ClassFoo5} from "./ExportCJSNamed_Class";
 //            ^                    ^                                 meta.brace.curly.js
 //             ^^^^^^^^^  ^^^^^^^^^                                  variable.other.readwrite.js
 //                      ^                                            meta.delimiter.comma.js
-//                                        ^                      ^   punctuation.definition.string.begin.js
+//                                        ^                          punctuation.definition.string.begin.js
+//                                                               ^   punctuation.definition.string.end.js
 //                                         ^^^^^^^^^^^^^^^^^^^^^^    string.quoted.module.js
 //                                                                ^  punctuation.terminator.statement.js
 import {foo4Inst, foo5Inst} from "./ExportCJSNamed_Class";
@@ -1151,7 +1153,8 @@ import {foo4Inst, foo5Inst} from "./ExportCJSNamed_Class";
 //     ^                  ^                                 meta.brace.curly.js
 //      ^^^^^^^^  ^^^^^^^^                                  variable.other.readwrite.js
 //              ^                                           meta.delimiter.comma.js
-//                               ^                      ^   punctuation.definition.string.begin.js
+//                               ^                          punctuation.definition.string.begin.js
+//                                                      ^   punctuation.definition.string.end.js
 //                                ^^^^^^^^^^^^^^^^^^^^^^    string.quoted.module.js
 //                                                       ^  punctuation.terminator.statement.js
 import type ClassFoo6 from "./issue-359";
@@ -1160,7 +1163,8 @@ import type ClassFoo6 from "./issue-359";
 //^^^^                ^^^^                 keyword.control.module.js
 //     ^^^^                                keyword.other.typedef.flowtype
 //          ^^^^^^^^^                      variable.other.readwrite.js
-//                         ^           ^   punctuation.definition.string.begin.js
+//                         ^               punctuation.definition.string.begin.js
+//                                     ^   punctuation.definition.string.end.js
 //                          ^^^^^^^^^^^    string.quoted.module.js
 //                                      ^  punctuation.terminator.statement.js
 import typeof ClassFoo6 from "./issue-359";
@@ -1169,7 +1173,8 @@ import typeof ClassFoo6 from "./issue-359";
 //^^^^                  ^^^^                 keyword.control.module.js
 //     ^^^^^^                                keyword.other.typedef.flowtype
 //            ^^^^^^^^^                      variable.other.readwrite.js
-//                           ^           ^   punctuation.definition.string.begin.js
+//                           ^               punctuation.definition.string.begin.js
+//                                       ^   punctuation.definition.string.end.js
 //                            ^^^^^^^^^^^    string.quoted.module.js
 //                                        ^  punctuation.terminator.statement.js
 

--- a/spec/fixtures/grammar/babel-sublime/jsx-es6.jsx
+++ b/spec/fixtures/grammar/babel-sublime/jsx-es6.jsx
@@ -7,7 +7,8 @@ import React from 'react';
  // <- keyword.control.module.js
 //^^^^       ^^^^           keyword.control.module.js
 //     ^^^^^                variable.other.readwrite.js
-//                ^     ^   punctuation.definition.string.begin.js
+//                ^         punctuation.definition.string.begin.js
+//                      ^   punctuation.definition.string.end.js
 //                 ^^^^^    string.quoted.module.js
 //                       ^  punctuation.terminator.statement.js
 import { InputsMixin } from './Forms';
@@ -16,7 +17,8 @@ import { InputsMixin } from './Forms';
 //^^^^                 ^^^^             keyword.control.module.js
 //     ^             ^                  meta.brace.curly.js
 //       ^^^^^^^^^^^                    variable.other.readwrite.js
-//                          ^       ^   punctuation.definition.string.begin.js
+//                          ^           punctuation.definition.string.begin.js
+//                                  ^   punctuation.definition.string.end.js
 //                           ^^^^^^^    string.quoted.module.js
 //                                   ^  punctuation.terminator.statement.js
 

--- a/spec/fixtures/grammar/babel-sublime/jsx-full-react-class.jsx
+++ b/spec/fixtures/grammar/babel-sublime/jsx-full-react-class.jsx
@@ -5,7 +5,8 @@ import React from 'react';
  // <- keyword.control.module.js
 //^^^^       ^^^^           keyword.control.module.js
 //     ^^^^^                variable.other.readwrite.js
-//                ^     ^   punctuation.definition.string.begin.js
+//                ^         punctuation.definition.string.begin.js
+//                      ^   punctuation.definition.string.end.js
 //                 ^^^^^    string.quoted.module.js
 //                       ^  punctuation.terminator.statement.js
 import { InputsMixin } from './Forms';
@@ -14,7 +15,8 @@ import { InputsMixin } from './Forms';
 //^^^^                 ^^^^             keyword.control.module.js
 //     ^             ^                  meta.brace.curly.js
 //       ^^^^^^^^^^^                    variable.other.readwrite.js
-//                          ^       ^   punctuation.definition.string.begin.js
+//                          ^           punctuation.definition.string.begin.js
+//                                  ^   punctuation.definition.string.end.js
 //                           ^^^^^^^    string.quoted.module.js
 //                                   ^  punctuation.terminator.statement.js
 

--- a/spec/fixtures/grammar/es6module.js
+++ b/spec/fixtures/grammar/es6module.js
@@ -5,7 +5,8 @@ import defaultMember from "module-name"
  // <- keyword.control.module.js
 //^^^^               ^^^^                keyword.control.module.js
 //     ^^^^^^^^^^^^^                     variable.other.readwrite.js
-//                        ^           ^  punctuation.definition.string.begin.js
+//                        ^              punctuation.definition.string.begin.js
+//                                    ^  punctuation.definition.string.end.js
 //                         ^^^^^^^^^^^   string.quoted.module.js
 import * as name from "module-name"
 // <- keyword.control.module.js
@@ -14,7 +15,8 @@ import * as name from "module-name"
 //     ^                             keyword.operator.module.all.js
 //       ^^                          keyword.control.module.reference.js
 //          ^^^^                     variable.other.readwrite.js
-//                    ^           ^  punctuation.definition.string.begin.js
+//                    ^              punctuation.definition.string.begin.js
+//                                ^  punctuation.definition.string.end.js
 //                     ^^^^^^^^^^^   string.quoted.module.js
 import { member } from "module-name"
 // <- keyword.control.module.js
@@ -22,7 +24,8 @@ import { member } from "module-name"
 //^^^^            ^^^^                keyword.control.module.js
 //     ^        ^                     meta.brace.curly.js
 //       ^^^^^^                       variable.other.readwrite.js
-//                     ^           ^  punctuation.definition.string.begin.js
+//                     ^              punctuation.definition.string.begin.js
+//                                 ^  punctuation.definition.string.end.js
 //                      ^^^^^^^^^^^   string.quoted.module.js
 import { member as alias } from "module-name"
 // <- keyword.control.module.js
@@ -31,7 +34,8 @@ import { member as alias } from "module-name"
 //     ^                 ^                     meta.brace.curly.js
 //       ^^^^^^    ^^^^^                       variable.other.readwrite.js
 //              ^^                             keyword.control.module.reference.js
-//                              ^           ^  punctuation.definition.string.begin.js
+//                              ^              punctuation.definition.string.begin.js
+//                                          ^  punctuation.definition.string.end.js
 //                               ^^^^^^^^^^^   string.quoted.module.js
 import { member1 , member2 } from "module-name"
 // <- keyword.control.module.js
@@ -40,7 +44,8 @@ import { member1 , member2 } from "module-name"
 //     ^                   ^                     meta.brace.curly.js
 //       ^^^^^^^   ^^^^^^^                       variable.other.readwrite.js
 //               ^                               meta.delimiter.comma.js
-//                                ^           ^  punctuation.definition.string.begin.js
+//                                ^              punctuation.definition.string.begin.js
+//                                            ^  punctuation.definition.string.end.js
 //                                 ^^^^^^^^^^^   string.quoted.module.js
 import { member1 , member2 as alias2 , [] } from "module-name"
 // <- keyword.control.module.js
@@ -51,7 +56,8 @@ import { member1 , member2 as alias2 , [] } from "module-name"
 //               ^                   ^                          meta.delimiter.comma.js
 //                         ^^                                   keyword.control.module.reference.js
 //                                     ^^                       meta.brace.square.js
-//                                               ^           ^  punctuation.definition.string.begin.js
+//                                               ^              punctuation.definition.string.begin.js
+//                                                           ^  punctuation.definition.string.end.js
 //                                                ^^^^^^^^^^^   string.quoted.module.js
 import defaultMember, { member [ , [] ] } from "module-name"
 // <- keyword.control.module.js
@@ -62,7 +68,8 @@ import defaultMember, { member [ , [] ] } from "module-name"
 //                    ^                 ^                     meta.brace.curly.js
 //                      ^^^^^^                                variable.other.object.js
 //                             ^   ^^ ^                       meta.brace.square.js
-//                                             ^           ^  punctuation.definition.string.begin.js
+//                                             ^              punctuation.definition.string.begin.js
+//                                                         ^  punctuation.definition.string.end.js
 //                                              ^^^^^^^^^^^   string.quoted.module.js
 import defaultMember, * as name from "module-name";
 // <- keyword.control.module.js
@@ -72,14 +79,16 @@ import defaultMember, * as name from "module-name";
 //                  ^                                meta.delimiter.comma.js
 //                    ^                              keyword.operator.module.all.js
 //                      ^^                           keyword.control.module.reference.js
-//                                   ^           ^   punctuation.definition.string.begin.js
+//                                   ^               punctuation.definition.string.begin.js
+//                                               ^   punctuation.definition.string.end.js
 //                                    ^^^^^^^^^^^    string.quoted.module.js
 //                                                ^  punctuation.terminator.statement.js
 import "module-name"
 // <- keyword.control.module.js
  // <- keyword.control.module.js
 //^^^^                keyword.control.module.js
-//     ^           ^  punctuation.definition.string.begin.js
+//     ^              punctuation.definition.string.begin.js
+//                 ^  punctuation.definition.string.end.js
 //      ^^^^^^^^^^^   string.quoted.module.js
 import type {UserID, User} , typeof something from "module-name"
 // <- keyword.control.module.js
@@ -89,7 +98,8 @@ import type {UserID, User} , typeof something from "module-name"
 //          ^            ^                                        meta.brace.curly.js
 //           ^^^^^^  ^^^^           ^^^^^^^^^                     variable.other.readwrite.js
 //                 ^       ^                                      meta.delimiter.comma.js
-//                                                 ^           ^  punctuation.definition.string.begin.js
+//                                                 ^              punctuation.definition.string.begin.js
+//                                                             ^  punctuation.definition.string.end.js
 //                                                  ^^^^^^^^^^^   string.quoted.module.js
 
 import defaultMember
@@ -141,7 +151,8 @@ import defaultMember
 // ^^^^                  keyword.other.typedef.flowtype
 //      ^^^              variable.other.readwrite.js
 //          ^^^^         keyword.control.module.js
-//               ^    ^  punctuation.definition.string.begin.js
+//               ^       punctuation.definition.string.begin.js
+//                    ^  punctuation.definition.string.end.js
 //                ^^^^   string.quoted.module.js
 
 
@@ -221,7 +232,8 @@ export * from "module-name"
  // <- keyword.control.module.js
 //^^^^   ^^^^                keyword.control.module.js
 //     ^                     keyword.operator.module.all.js
-//            ^           ^  punctuation.definition.string.begin.js
+//            ^              punctuation.definition.string.begin.js
+//                        ^  punctuation.definition.string.end.js
 //             ^^^^^^^^^^^   string.quoted.module.js
 export { name1, name2, nameN } from "module-name"
 // <- keyword.control.module.js
@@ -230,7 +242,8 @@ export { name1, name2, nameN } from "module-name"
 //     ^                     ^                     meta.brace.curly.js
 //       ^^^^^  ^^^^^  ^^^^^                       variable.other.readwrite.js
 //            ^      ^                             meta.delimiter.comma.js
-//                                  ^           ^  punctuation.definition.string.begin.js
+//                                  ^              punctuation.definition.string.begin.js
+//                                              ^  punctuation.definition.string.end.js
 //                                   ^^^^^^^^^^^   string.quoted.module.js
 export { import1 as name1, import2 as name2, nameN } from "module-name"
 // <- keyword.control.module.js
@@ -240,14 +253,16 @@ export { import1 as name1, import2 as name2, nameN } from "module-name"
 //       ^^^^^^^    ^^^^^  ^^^^^^^    ^^^^^  ^^^^^                       variable.other.readwrite.js
 //               ^^                ^^                                    keyword.control.module.reference.js
 //                       ^                 ^                             meta.delimiter.comma.js
-//                                                        ^           ^  punctuation.definition.string.begin.js
+//                                                        ^              punctuation.definition.string.begin.js
+//                                                                    ^  punctuation.definition.string.end.js
 //                                                         ^^^^^^^^^^^   string.quoted.module.js
 export someIdentifier from "someModule"
 // <- keyword.control.module.js
  // <- keyword.control.module.js
 //^^^^                ^^^^               keyword.control.module.js
 //     ^^^^^^^^^^^^^^                    variable.other.readwrite.js
-//                         ^          ^  punctuation.definition.string.begin.js
+//                         ^             punctuation.definition.string.begin.js
+//                                    ^  punctuation.definition.string.end.js
 //                          ^^^^^^^^^^   string.quoted.module.js
 export someIdentifier, { namedIdentifier } from "someModule"
 // <- keyword.control.module.js
@@ -256,7 +271,8 @@ export someIdentifier, { namedIdentifier } from "someModule"
 //     ^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^                      variable.other.readwrite.js
 //                   ^                                        meta.delimiter.comma.js
 //                     ^                 ^                    meta.brace.curly.js
-//                                              ^          ^  punctuation.definition.string.begin.js
+//                                              ^             punctuation.definition.string.begin.js
+//                                                         ^  punctuation.definition.string.end.js
 //                                               ^^^^^^^^^^   string.quoted.module.js
 
 export type User = {
@@ -296,7 +312,8 @@ export type User = {
  } from "aaaa"
  // <- meta.brace.curly.js
 // ^^^^         keyword.control.module.js
-//      ^    ^  punctuation.definition.string.begin.js
+//      ^       punctuation.definition.string.begin.js
+//           ^  punctuation.definition.string.end.js
 //       ^^^^   string.quoted.module.js
 
 

--- a/spec/fixtures/grammar/everythingJs/es2015-module.js
+++ b/spec/fixtures/grammar/everythingJs/es2015-module.js
@@ -16,7 +16,8 @@ import i0 from "module";
  // <- keyword.control.module.js
 //^^^^    ^^^^            keyword.control.module.js
 //     ^^                 variable.other.readwrite.js
-//             ^      ^   punctuation.definition.string.begin.js
+//             ^          punctuation.definition.string.begin.js
+//                    ^   punctuation.definition.string.end.js
 //              ^^^^^^    string.quoted.module.js
 //                     ^  punctuation.terminator.statement.js
 import * as i1 from "module";
@@ -26,7 +27,8 @@ import * as i1 from "module";
 //     ^                       keyword.operator.module.all.js
 //       ^^                    keyword.control.module.reference.js
 //          ^^                 variable.other.readwrite.js
-//                  ^      ^   punctuation.definition.string.begin.js
+//                  ^          punctuation.definition.string.begin.js
+//                         ^   punctuation.definition.string.end.js
 //                   ^^^^^^    string.quoted.module.js
 //                          ^  punctuation.terminator.statement.js
 import {} from "module";
@@ -34,7 +36,8 @@ import {} from "module";
  // <- keyword.control.module.js
 //^^^^    ^^^^            keyword.control.module.js
 //     ^^                 meta.brace.curly.js
-//             ^      ^   punctuation.definition.string.begin.js
+//             ^          punctuation.definition.string.begin.js
+//                    ^   punctuation.definition.string.end.js
 //              ^^^^^^    string.quoted.module.js
 //                     ^  punctuation.terminator.statement.js
 import { i2, a as i3, } from "module";
@@ -45,7 +48,8 @@ import { i2, a as i3, } from "module";
 //       ^^  ^    ^^                    variable.other.readwrite.js
 //         ^        ^                   meta.delimiter.comma.js
 //             ^^                       keyword.control.module.reference.js
-//                           ^      ^   punctuation.definition.string.begin.js
+//                           ^          punctuation.definition.string.begin.js
+//                                  ^   punctuation.definition.string.end.js
 //                            ^^^^^^    string.quoted.module.js
 //                                   ^  punctuation.terminator.statement.js
 import i4, * as i5 from "module";
@@ -56,7 +60,8 @@ import i4, * as i5 from "module";
 //       ^                         meta.delimiter.comma.js
 //         ^                       keyword.operator.module.all.js
 //           ^^                    keyword.control.module.reference.js
-//                      ^      ^   punctuation.definition.string.begin.js
+//                      ^          punctuation.definition.string.begin.js
+//                             ^   punctuation.definition.string.end.js
 //                       ^^^^^^    string.quoted.module.js
 //                              ^  punctuation.terminator.statement.js
 import i6, {} from "module";
@@ -66,7 +71,8 @@ import i6, {} from "module";
 //     ^^                     variable.other.readwrite.js
 //       ^                    meta.delimiter.comma.js
 //         ^^                 meta.brace.curly.js
-//                 ^      ^   punctuation.definition.string.begin.js
+//                 ^          punctuation.definition.string.begin.js
+//                        ^   punctuation.definition.string.end.js
 //                  ^^^^^^    string.quoted.module.js
 //                         ^  punctuation.terminator.statement.js
 import i7, { i8, var as i9 } from "module";
@@ -77,14 +83,16 @@ import i7, { i8, var as i9 } from "module";
 //       ^     ^                             meta.delimiter.comma.js
 //         ^               ^                 meta.brace.curly.js
 //                   ^^                      keyword.control.module.reference.js
-//                                ^      ^   punctuation.definition.string.begin.js
+//                                ^          punctuation.definition.string.begin.js
+//                                       ^   punctuation.definition.string.end.js
 //                                 ^^^^^^    string.quoted.module.js
 //                                        ^  punctuation.terminator.statement.js
 import "module";
 // <- keyword.control.module.js
  // <- keyword.control.module.js
 //^^^^            keyword.control.module.js
-//     ^      ^   punctuation.definition.string.begin.js
+//     ^          punctuation.definition.string.begin.js
+//            ^   punctuation.definition.string.end.js
 //      ^^^^^^    string.quoted.module.js
 //             ^  punctuation.terminator.statement.js
 
@@ -93,7 +101,8 @@ export * from "module";
  // <- keyword.control.module.js
 //^^^^   ^^^^            keyword.control.module.js
 //     ^                 keyword.operator.module.all.js
-//            ^      ^   punctuation.definition.string.begin.js
+//            ^          punctuation.definition.string.begin.js
+//                   ^   punctuation.definition.string.end.js
 //             ^^^^^^    string.quoted.module.js
 //                    ^  punctuation.terminator.statement.js
 export {} from "module";
@@ -101,7 +110,8 @@ export {} from "module";
  // <- keyword.control.module.js
 //^^^^    ^^^^            keyword.control.module.js
 //     ^^                 meta.brace.curly.js
-//             ^      ^   punctuation.definition.string.begin.js
+//             ^          punctuation.definition.string.begin.js
+//                    ^   punctuation.definition.string.end.js
 //              ^^^^^^    string.quoted.module.js
 //                     ^  punctuation.terminator.statement.js
 export { i0, i1 as a, i2 as var, } from "module";
@@ -112,7 +122,8 @@ export { i0, i1 as a, i2 as var, } from "module";
 //       ^^  ^^    ^  ^^    ^^^                    variable.other.readwrite.js
 //         ^        ^          ^                   meta.delimiter.comma.js
 //              ^^       ^^                        keyword.control.module.reference.js
-//                                      ^      ^   punctuation.definition.string.begin.js
+//                                      ^          punctuation.definition.string.begin.js
+//                                             ^   punctuation.definition.string.end.js
 //                                       ^^^^^^    string.quoted.module.js
 //                                              ^  punctuation.terminator.statement.js
 export {};

--- a/spec/fixtures/grammar/misc.js
+++ b/spec/fixtures/grammar/misc.js
@@ -75,7 +75,8 @@ function foo(x /*: number*/) /*: string*/ {}
 //               ^    ^  ^                      variable.other.constant.js
 //                ^    ^                        meta.delimiter.comma.js
 //                  ^      ^                    meta.brace.curly.js
-//                                ^       ^     punctuation.definition.string.begin.js
+//                                ^             punctuation.definition.string.begin.js
+//                                        ^     punctuation.definition.string.end.js
 //                                 ^^^^^^^      string.quoted.module.js
 /*:: import typeof D, { E, F } from './types';*/
 // <- punctuation.definition.comment.js
@@ -87,7 +88,8 @@ function foo(x /*: number*/) /*: string*/ {}
 //                 ^    ^  ^                      variable.other.constant.js
 //                  ^    ^                        meta.delimiter.comma.js
 //                    ^      ^                    meta.brace.curly.js
-//                                  ^       ^     punctuation.definition.string.begin.js
+//                                  ^             punctuation.definition.string.begin.js
+//                                          ^     punctuation.definition.string.end.js
 //                                   ^^^^^^^      string.quoted.module.js
 
 // Calls language-mustache & language-html from a object template: backtick

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -49,4 +49,5 @@ describe 'Grammar', ->
 
   # misc Tests
   grammarTest path.join(__dirname, 'fixtures/grammar/misc.js')
-  grammarTest path.join(__dirname, 'fixtures/grammar/es6module.js')
+  describe 'ES6 modules', ->
+    grammarTest path.join(__dirname, 'fixtures/grammar/es6module.js')


### PR DESCRIPTION
Modify grammar to mark closing quotes properly in import/export module name string literals.
Before:
```javascript
import * from "module-name"
              ^           ^  punctuation.definition.string.begin.js
```
After:
```javascript
import * from "module-name"
              ^              punctuation.definition.string.begin.js
                          ^  punctuation.definition.string.end.js
```
This behaviour match other contexts for quotes (and language-javascript grammar)
