### PR TITLE
Add support for JSX indent pattern

### DIFF
--- a/settings/language-babel.json
+++ b/settings/language-babel.json
@@ -3,8 +3,8 @@
     "editor": {
       "commentStart": "// ",
       "foldEndPattern": "^\\s*\\}|^\\s*\\]|^\\s*\\)",
-      "increaseIndentPattern": "{[^}\"']*$|\\[[^\\]\"']*$|\\([^)\"']*$",
-      "decreaseIndentPattern": "^\\s*(\\s*/[*].*[*]/\\s*)*[}\\])]",
+      "increaseIndentPattern": "{[^}\"']*$|\\[[^\\]\"']*$|\\([^)\"']*$|<[a-zA-Z][^/]*$|^\\s*>$",
+      "decreaseIndentPattern": "^\\s*(\\s*/[*].*[*]/\\s*)*[}\\])]|^\\s*(</|/>)",
       "nonWordCharacters": "/\\()\"':,.;<>~!@#%^&*|+=[]{}`?-…"
     }
   },


### PR DESCRIPTION
When you do cmd-ctrl-up and down, Atom reformats the code based on the indent regex. Making it understand jsx fixes this issue. But it also has the nice side benefit of properly indenting when you press enter :)

Test Plan:
See videos for indentation
![](http://g.recordit.co/BXghyIDy2U.gif)

and de-indentation
![](http://g.recordit.co/qKczLsEbxL.gif)