### PR TITLE
Allow `yield <SomeJSX />` syntax

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -2176,7 +2176,7 @@
       "comment": "Avoid < operator expressions as best we can using Zertosh's regex",
       "patterns": [
         {
-          "begin": "(?<=\\(|{|\\[|,|&&|\\|\\||\\?|:|=|=>|\\Wreturn|^return|\\Wdefault|\\Wvoid|^void|^)\\s*+(?=<[$_\\p{L}])",
+          "begin": "(?<=\\(|{|\\[|,|&&|\\|\\||\\?|:|=|=>|\\Wreturn|^return|\\Wyield|^yield|\\Wdefault|\\Wvoid|^void|^)\\s*+(?=<[$_\\p{L}])",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "patterns": [


### PR DESCRIPTION
Since JSX is a materialized UI _data_ and first-class citizen, it can be `yield`'ed from (async) generator.

Here is how the syntax highlighting looks right now:
![image](https://cloud.githubusercontent.com/assets/858295/24332050/66278ef0-1248-11e7-90ad-ae98f2b2f66b.png)

You can observe the difference in the first line with `yield` and in the line with `return`. Even worse it becames when you use words that are also reserved:
![image](https://cloud.githubusercontent.com/assets/858295/24332071/d216a8da-1248-11e7-9be5-dc5620dff7b0.png)
