### PR TITLE
styled-components: add withConfig method support

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -977,7 +977,7 @@
         },
         {
           "comment": "Styled CSS tag functions",
-          "begin": "(?<!\\.)\\s*+(?:(\\bstyled)\\s*(\\.)\\s*((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*(\\.)\\s*(attrs))\\s*(?=\\()",
+          "begin": "(?<!\\.)\\s*+(?:(\\bstyled)\\s*(\\.)\\s*((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*(\\.)\\s*(attrs|withConfig))\\s*(?=\\()",
           "end": "(?=.|\\n)",
           "applyEndPatternLast": 1,
           "beginCaptures": {


### PR DESCRIPTION
Currently language-babel does not highlight css rules for next case:

![image](https://user-images.githubusercontent.com/5237085/28007619-c2be3bd4-655c-11e7-8e28-5415729caf89.png)

This PR should fix this problem.