### PR TITLE
Added .mjs filetype to recognised file types

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -11,7 +11,8 @@
     "es",
     "babel",
     "jsx",
-    "flow"
+    "flow",
+    "mjs"
   ],
   "patterns": [
     { "include": "#core" }


### PR DESCRIPTION
Basically it's been pretty much decided now that `.mjs` as a file extension will be used to determine that a file is a JavaScript module in Node.js (see [here](https://github.com/nodejs/node-eps/blob/master/002-es-modules.md) and [here](https://github.com/nodejs/node/pull/14369)).

Tooling is [already starting to support it](https://github.com/standard-things/esm), so I thought it'd be nice to at least get syntax highlighting on those files.