### PR TITLE
set global attributes for (auto)completion sake

### DIFF
--- a/lib/completions-jsx.coffee
+++ b/lib/completions-jsx.coffee
@@ -87,7 +87,6 @@ globalAttributes: [
         { name: 'spellCheck'}
         { name: 'tabIndex'}
         { name: 'title'}
-        { name: 'translate'}
 ]
 
 htmlElements: [

--- a/lib/completions-jsx.coffee
+++ b/lib/completions-jsx.coffee
@@ -77,16 +77,15 @@ globalAttributes: [
 	{ name: 'data-'}
 	{ name: 'aria-'}
 	{ name: 'style'}
-        { name: 'accesskey'}
-        { name: 'contenteditable'}
-        { name: 'contextmenu'}
+        { name: 'accessKey'}
+        { name: 'contentEditable'}
+        { name: 'contextMenu'}
         { name: 'dir'}
         { name: 'draggable'}
-        { name: 'dropzone'}
         { name: 'hidden'}
         { name: 'lang'}
-        { name: 'spellcheck'}
-        { name: 'tabindex'}
+        { name: 'spellCheck'}
+        { name: 'tabIndex'}
         { name: 'title'}
         { name: 'translate'}
 ]

--- a/lib/completions-jsx.coffee
+++ b/lib/completions-jsx.coffee
@@ -77,6 +77,18 @@ globalAttributes: [
 	{ name: 'data-'}
 	{ name: 'aria-'}
 	{ name: 'style'}
+        { name: 'accesskey'}
+        { name: 'contenteditable'}
+        { name: 'contextmenu'}
+        { name: 'dir'}
+        { name: 'draggable'}
+        { name: 'dropzone'}
+        { name: 'hidden'}
+        { name: 'lang'}
+        { name: 'spellcheck'}
+        { name: 'tabindex'}
+        { name: 'title'}
+        { name: 'translate'}
 ]
 
 htmlElements: [

--- a/lib/completions-jsx.coffee
+++ b/lib/completions-jsx.coffee
@@ -76,6 +76,7 @@ globalAttributes: [
 	{ name: 'dangerouslySetInnerHTML'}
 	{ name: 'data-'}
 	{ name: 'aria-'}
+	{ name: 'style'}
 ]
 
 htmlElements: [


### PR DESCRIPTION
This PR started as just adding the `style` attribute to globally available attributes. The rest have been added on via @mpacer, following the official guide to [supported attributes in React](https://facebook.github.io/react/docs/dom-elements.html#all-supported-html-attributes).