### PR TITLE
Detect .babelrc.js configuration files

### DIFF
--- a/lib/transpiler.coffee
+++ b/lib/transpiler.coffee
@@ -391,9 +391,13 @@ class Transpiler
 # check for prescence of a .babelrc file path fromDir to root
   isBabelrcInPath: (fromDir) ->
     # enviromnents used in babelrc
-    babelrc = '.babelrc'
-    babelrcFile = path.join fromDir, babelrc
-    if fs.existsSync babelrcFile
+    babelrc = [
+      '.babelrc'
+      '.babelrc.js' # Babel 7.0 and newer
+    ]
+    babelrcFiles = babelrc.map (file) -> path.join(fromDir, file)
+
+    if babelrcFiles.some fs.existsSync
       return true
     if fromDir != path.dirname(fromDir)
       return @isBabelrcInPath path.dirname(fromDir)


### PR DESCRIPTION
Support for plain JS Babel configuration has been added in Babel 7.0.
See the latest blog post:

https://babeljs.io/blog/2017/09/12/planning-for-7.0

... and the related PR:

https://github.com/babel/babel/pull/4892

> PS. I sure hope this is valid Coffee. Not used this language for some time and not sure how to run the test suite. 🤔