### PR TITLE
Lazy require some expensive dependencies

### DIFF
--- a/lib/auto-complete-emmet-css.js
+++ b/lib/auto-complete-emmet-css.js
@@ -1,9 +1,6 @@
 /*global atom*/
 "use babel";
 
-const {expand} = require('@emmetio/expand-abbreviation');
-
-
 module.exports = {
   selector: '.source.inside-js.css.styled, .source.css.styled',
   disableForSelector:
@@ -35,6 +32,8 @@ module.exports = {
   emmetSuggestion(prefix) {
     const completion = [];
     try {
+      // Expensive dependency: use a lazy require.
+      const {expand} = require('@emmetio/expand-abbreviation');
       const emmetAbbreviation = expand(prefix, {
         syntax: 'css',
         field: (index, placeholder) =>

--- a/lib/auto-indent.coffee
+++ b/lib/auto-indent.coffee
@@ -1,10 +1,8 @@
 {CompositeDisposable, File, Range, Point} = require 'atom'
-fs = require 'fs-plus'
 path = require 'path'
 autoCompleteJSX = require './auto-complete-jsx'
 DidInsertText = require './did-insert-text'
 stripJsonComments = require 'strip-json-comments'
-YAML = require 'js-yaml'
 
 
 NO_TOKEN                = 0
@@ -710,10 +708,14 @@ class AutoIndent
 
   # to create indents. We can read and return the rules properties or undefined
   readEslintrcOptions: (eslintrcFile) ->
+    # Expensive dependency: use a lazy require.
+    fs = require 'fs-plus'
     # get local path overides
     if fs.existsSync eslintrcFile
       fileContent = stripJsonComments(fs.readFileSync(eslintrcFile, 'utf8'))
       try
+        # Expensive dependency: use a lazy require.
+        YAML = require 'js-yaml'
         eslintRules = (YAML.safeLoad fileContent).rules
         if eslintRules then return eslintRules
       catch err

--- a/lib/transpiler.coffee
+++ b/lib/transpiler.coffee
@@ -1,7 +1,13 @@
 {Task, CompositeDisposable } = require 'atom'
-fs = require 'fs-plus'
 path = require 'path'
 pathIsInside = require '../node_modules/path-is-inside'
+
+# Lazily require fs-plus to avoid blocking startup.
+fs = new Proxy({}, {
+  get: (target, key) ->
+    target.fs ?= require 'fs-plus'
+    target.fs[key]
+})
 
 # setup JSON Schema to parse .languagebabel configs
 languagebabelSchema = {


### PR DESCRIPTION
I've noticed that `language-babel` often contributes ~300ms to activation time. Looking at `atom --profile-startup`, we can see that this is actually due to three big and easily deferrable dependencies:

<img width="593" alt="screen shot 2017-12-12 at 10 23 14 pm" src="https://user-images.githubusercontent.com/577378/33924601-a9ab9bce-df8b-11e7-921f-2705b0514d56.png">

It's extremely easy to get these out of the startup path by moving the require statements closer to their uses. The three major suspects in the screenshot are:

- `@emmetio/expand-abbreviation` (~60ms)
- `fs-plus` (~80ms)
- `js-yaml` (~150ms)

These are typically lower in practice due to Atom's v8 compile cache, but once these are lazily required `language-babel` consistently takes less than 100ms of activation time according to timecop.