### PR TITLE
fix(indent): ensure eslintrc is a file

### DIFF
--- a/lib/auto-indent.coffee
+++ b/lib/auto-indent.coffee
@@ -711,7 +711,7 @@ class AutoIndent
     # Expensive dependency: use a lazy require.
     fs = require 'fs-plus'
     # get local path overides
-    if fs.existsSync eslintrcFile
+    if fs.isFileSync eslintrcFile
       fileContent = stripJsonComments(fs.readFileSync(eslintrcFile, 'utf8'))
       try
         # Expensive dependency: use a lazy require.

--- a/spec/auto-indent-spec.coffee
+++ b/spec/auto-indent-spec.coffee
@@ -43,16 +43,25 @@ describe 'auto-indent', ->
     it 'returns an empty object on a missing .eslintrc', ->
       expect(autoIndent.readEslintrcOptions('.missing')).toEqual({})
 
-    it 'returns and empty Object and a notification message on bad eslint', ->
-      spyOn(fs, 'existsSync').andReturn(true)
+    it 'returns an empty Object and a notification message on bad eslint', ->
+      spyOn(fs, 'isFileSync').andReturn(true)
       spyOn(fs, 'readFileSync').andReturn('{')
       spyOn(notifications, 'addError').andCallThrough()
       obj = autoIndent.readEslintrcOptions()
       expect(notifications.addError).toHaveBeenCalled()
       expect(obj).toEqual({})
 
+    it 'returns an empty Object when attempting to read something other than a file', ->
+      spyOn(fs, 'isFileSync').andReturn(false)
+      spyOn(fs, 'readFileSync')
+      spyOn(notifications, 'addError').andCallThrough()
+      obj = autoIndent.readEslintrcOptions()
+      expect(fs.readFileSync).not.toHaveBeenCalled()
+      expect(notifications.addError).not.toHaveBeenCalled()
+      expect(obj).toEqual({})
+
     it 'returns an empty Object when eslint with no rules is read', ->
-      spyOn(fs, 'existsSync').andReturn(true)
+      spyOn(fs, 'isFileSync').andReturn(true)
       spyOn(fs, 'readFileSync').andReturn('{}')
       spyOn(notifications, 'addError').andCallThrough()
       obj = autoIndent.readEslintrcOptions()


### PR DESCRIPTION
Overview
--------

To better match the behavior of eslint itself, this will no longer throw an error if `.eslintrc` is a directory.

Changes
-------

- Check that candidate eslintrc exists AND is file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gandm/language-babel/470)
<!-- Reviewable:end -->
