### PR TITLE
maxLineLength + embedded grammars

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -1,10 +1,11 @@
 {
   "name": "Babel ES6 JavaScript",
   "scopeName": "source.js.jsx",
+  "injectionSelector": "source.embedded.jsx",
   "foldingStartMarker": "(/\\*|{|\\()",
   "foldingEndMarker": "(\\*/|\\}|\\))",
   "firstLineMatch": "^#!\\s*/.*\\b(node|js)$\\n?",
-  "limitLineLength": false,
+  "maxLineLength": 1000,
   "fileTypes": [
     "js",
     "es6",
@@ -20,7 +21,6 @@
   "repository": {
     "core": {
       "patterns": [
-        { "include": "#ignore-long-lines" },
         { "include": "#flowtype-keywords" },
         { "include": "#literal-labels" },
         { "include": "#literal-for" },
@@ -31,7 +31,6 @@
     },
     "expression": {
       "patterns": [
-        { "include": "#ignore-long-lines" },
         { "include": "#multiline-arrow-function-generics"},
         { "include": "#jsx" },
         { "include": "#es7-decorators" },
@@ -59,15 +58,6 @@
         { "include": "#literal-variable" },
         { "include": "#literal-punctuation" },
         { "include": "#fat-arrow"}
-      ]
-    },
-    "ignore-long-lines": {
-      "comment": "long lines shouldn't be parsed for performance reasons as regex's are per line",
-      "comment": "so set at arbitary 1000 chars to avoid parsing minified files",
-      "patterns": [
-        {
-          "match": "^.{1000,}"
-        }
       ]
     },
     "multiline-arrow-function-generics": {

--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -5,7 +5,7 @@
   "foldingStartMarker": "(/\\*|{|\\()",
   "foldingEndMarker": "(\\*/|\\}|\\))",
   "firstLineMatch": "^#!\\s*/.*\\b(node|js)$\\n?",
-  "maxLineLength": 1000,
+  "limitLineLength": false,
   "fileTypes": [
     "js",
     "es6",
@@ -21,6 +21,7 @@
   "repository": {
     "core": {
       "patterns": [
+        { "include": "#ignore-long-lines" },
         { "include": "#flowtype-keywords" },
         { "include": "#literal-labels" },
         { "include": "#literal-for" },
@@ -31,6 +32,7 @@
     },
     "expression": {
       "patterns": [
+        { "include": "#ignore-long-lines" },
         { "include": "#multiline-arrow-function-generics"},
         { "include": "#jsx" },
         { "include": "#es7-decorators" },
@@ -58,6 +60,15 @@
         { "include": "#literal-variable" },
         { "include": "#literal-punctuation" },
         { "include": "#fat-arrow"}
+      ]
+    },
+    "ignore-long-lines": {
+      "comment": "long lines shouldn't be parsed for performance reasons as regex's are per line",
+      "comment": "so set at arbitary 1000 chars to avoid parsing minified files",
+      "patterns": [
+        {
+          "match": "^.{1000,}"
+        }
       ]
     },
     "multiline-arrow-function-generics": {


### PR DESCRIPTION
This changes two things:

1. The setting `limitLineLength` has been replaced by `maxLineLength`. This is then set to 1000, and the related rules that were in effect are deleted because they are now redundant.

2. The property `injectionSelector` is added with a value of `source.embedded.jsx`. This means that when the scope `source.embedded.jsx` is encountered in another file, it will automatically use this packages grammar for the duration of the scope. For example, the scope will be encountered in a markdown file using `language-gfm` if the following is present:
````
```jsx
<jsx code>
```
````