### PR TITLE
Fix for #481

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -1,7 +1,6 @@
 {
   "name": "Babel ES6 JavaScript",
   "scopeName": "source.js.jsx",
-  "injectionSelector": "source.embedded.jsx",
   "foldingStartMarker": "(/\\*|{|\\()",
   "foldingEndMarker": "(\\*/|\\}|\\))",
   "firstLineMatch": "^#!\\s*/.*\\b(node|js)$\\n?",

--- a/grammars/Embedded Babel Language.json
+++ b/grammars/Embedded Babel Language.json
@@ -1,0 +1,9 @@
+{
+  "scopeName": "source.embedded.js.jsx",
+  "injectionSelector": "source.embedded.jsx",
+  "patterns": [
+    {
+      "include": "source.js.jsx"
+    }
+  ]
+}


### PR DESCRIPTION
Fix #481

This change removes the `injectionSelector` property from the main grammar, which was causing a bug with syntax highlighting being applied to the file.

Instead, it makes a new grammar file called `Embedded Babel Language.json`, which effectively does the same thing as `injectionSelector` but isolates it to an independent grammar. It does not have `name`, `fileTypes`, etc. because it should not appear in the language selection menu or be applied to a file directly. It will however work when the `source.embedded.jsx` scope is reached in another grammar (prime example being in markdown).

The `scopeName` property appears to be necessary (it will not apply without it), but any value besides `source.js.jsx` seems to work. The scope itself does not get applied to the embedded code anyway though.

I was able to reproduce the bug raised in #481 consistently, and this change appears to have fixed it. Highlighting is now applied on reopening Atom, and embedded code still works too.