### PR TITLE
Fix syntax highlighting for function calls with Flow type arguments

### DIFF
--- a/grammars/Babel Language.json
+++ b/grammars/Babel Language.json
@@ -448,6 +448,26 @@
         }
       ]
     },
+    "type-argument-brackets": {
+      "patterns": [
+        {
+          "comment": "Type arguments. This is complicated since we don't want to match things like foo < 123 || bar > baz",
+          "name": "meta.type-arguments.flowtype",
+          "begin": "\\s*+(<)(?=((?:(?>[^<>]+)|<\\g<-1>>)*)>)",
+          "end": "\\s*(>)",
+          "endCaptures": {
+            "1": { "name": "punctuation.flowtype" }
+          },
+          "beginCaptures": {
+            "1": { "name": "punctuation.flowtype" }
+          },
+          "patterns": [
+            { "include": "#flowtype-parse-types" },
+            { "include": "#literal-comma" }
+          ]
+        }
+      ]
+    },
     "square-brackets": {
       "patterns": [
         {
@@ -1364,6 +1384,8 @@
         { "include": "#comments" },
         { "include": "#literal-keywords" },
         {
+          "comment": "A new expression with no type params or arguments, like new Foo()",
+          "name": "meta.new-class.without-arguments.js",
           "match": "(?<!\\.)\\s*+(\\bnew\\b)\\s*+((\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?(\\()\\s*+(\\)))",
           "captures": {
             "1": { "name": "keyword.operator.new.js" },
@@ -1376,7 +1398,27 @@
           }
         },
         {
-          "begin": "(?<!\\.)\\s*+(\\bnew\\b)\\s*+((\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?(?=\\())",
+          "comment": "A new expression with type params and no arguments, like new Foo<string>()",
+          "name": "meta.new-class.without-arguments.js",
+          "begin": "(?<!\\.)\\s*+(\\bnew\\b)\\s*+((\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?\\s*+(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)\\s*+(\\()\\s*+(\\))))",
+          "end": "(?=.)",
+          "applyEndPatternLast": 1,
+          "beginCaptures": {
+            "1": { "name": "keyword.operator.new.js" },
+            "2": { "name": "meta.function-call.without-arguments.js" },
+            "3": { "name": "keyword.operator.private.js" },
+            "4": { "name": "entity.name.type.instance.js" },
+            "5": { "name": "keyword.operator.existential.js"}
+          },
+          "patterns": [
+            { "include": "#type-argument-brackets" },
+            { "include": "#round-brackets" }
+          ]
+        },
+        {
+          "comment": "A new expression with arguments and maybe type params, like new Foo<string>(123)",
+          "name": "meta.new-class.with-arguments.js",
+          "begin": "(?<!\\.)\\s*+(\\bnew\\b)\\s*+((\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?\\s*+(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+\\())",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -1387,11 +1429,13 @@
             "5": { "name": "keyword.operator.existential.js"}
           },
           "patterns": [
+            { "include": "#type-argument-brackets" },
             { "include": "#round-brackets" }
           ]
         },
-        { "include": "#literal-operators" },        
+        { "include": "#literal-operators" },
         {
+          "comment": "A call expression with no type params or arguments, like foo()",
           "name": "meta.function-call.without-arguments.js",
           "match": "(?<!\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?(\\()\\s*+(\\))",
           "captures": {
@@ -1403,9 +1447,25 @@
           }
         },
         {
-          "comment": "maybe in array form e.g. foo[bar]()",
+          "comment": "A call expression with type params and no arguments, like foo<string>()",
           "name": "meta.function-call.without-arguments.js",
-          "begin": "(?<!\\.)\\s*+((\\bnew\\b)*)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)(?=\\s*(\\[(?:(?>[^\\[\\]]+)|\\g<-1>)*\\])\\s*+\\(\\s*+\\))",
+          "begin": "(?<!\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?\\s*+(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)\\s*+(\\()\\s*+(\\)))",
+          "end": "(?=.)",
+          "applyEndPatternLast": 1,
+          "beginCaptures": {
+            "1": { "name": "keyword.operator.private.js" },
+            "2": { "name": "entity.name.function.js" },
+            "3": { "name": "keyword.operator.existential.js"}
+          },
+          "patterns": [
+            { "include": "#type-argument-brackets" },
+            { "include": "#round-brackets" }
+          ]
+        },
+        {
+          "comment": "maybe in array form e.g. foo[bar]() or foo[bar]<string>()",
+          "name": "meta.function-call.without-arguments.js",
+          "begin": "(?<!\\.)\\s*+((\\bnew\\b)*)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)(?=\\s*(\\[(?:(?>[^\\[\\]]+)|\\g<-1>)*\\])\\s*+(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+\\(\\s*+\\))",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -1415,12 +1475,14 @@
           },
           "patterns": [
             { "include": "#square-brackets"},
+            { "include": "#type-argument-brackets" },
             { "include": "#round-brackets" }
           ]
         },
         {
+          "comment": "A call expression with arguments and maybe type params, like foo(123) or foo<string>(123)",
           "name": "meta.function-call.with-arguments.js",
-          "begin": "(?<!\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?(?=\\()",
+          "begin": "(?<!\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?\\s*+(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+\\()",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -1429,13 +1491,14 @@
             "3": { "name": "keyword.operator.existential.js"}
           },
           "patterns": [
+            { "include": "#type-argument-brackets" },
             { "include": "#round-brackets" }
           ]
         },
         {
-          "comment": "maybe in array form e.g. foo[bar]()",
-          "name": "meta.function-call.without-arguments.js",
-          "begin": "(?<!\\.)\\s*+((\\bnew\\b)*)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\g<-1>)*\\])\\s*+\\()",
+          "comment": "maybe in array form e.g. foo[bar](123)",
+          "name": "meta.function-call.with-arguments.js",
+          "begin": "(?<!\\.)\\s*+((\\bnew\\b)*)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\g<-1>)*\\])\\s*+(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+\\()",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -1445,6 +1508,7 @@
           },
           "patterns": [
             { "include": "#square-brackets"},
+            { "include": "#type-argument-brackets" },
             { "include": "#round-brackets" }
           ]
         }

--- a/spec/fixtures/grammar/babel-sublime/flow-function-call-with-type-arguments.js
+++ b/spec/fixtures/grammar/babel-sublime/flow-function-call-with-type-arguments.js
@@ -1,0 +1,295 @@
+// SYNTAX TEST "source.js.jsx"
+
+new MyInstance();
+// <- meta.new-class.without-arguments.js keyword.operator.new.js
+ // <- meta.new-class.without-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^  meta.new-class.without-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.without-arguments.js
+//            ^^  meta.brace.round.js
+//              ^ punctuation.terminator.statement.js
+
+new MyInstance<string>();
+// <- meta.new-class.without-arguments.js keyword.operator.new.js
+ // <- meta.new-class.without-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^  meta.new-class.without-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.without-arguments.js
+//            ^^^^^^^^ meta.type-arguments.flowtype
+//            ^ punctuation.flowtype
+//             ^^^^^^ support.type.builtin.primitive.flowtype
+//                   ^ punctuation.flowtype
+//                    ^^  meta.brace.round.js
+//                      ^ punctuation.terminator.statement.js
+
+new MyInstance < string > ();
+// <- meta.new-class.without-arguments.js keyword.operator.new.js
+ // <- meta.new-class.without-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^  meta.new-class.without-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.without-arguments.js
+//             ^^^^^^^^^^ meta.type-arguments.flowtype
+//             ^        ^ punctuation.flowtype
+//               ^^^^^^ support.type.builtin.primitive.flowtype
+//                        ^^  meta.brace.round.js
+//                          ^ punctuation.terminator.statement.js
+
+new MyInstance<Baz<string>, number>();
+// <- meta.new-class.without-arguments.js keyword.operator.new.js
+ // <- meta.new-class.without-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.new-class.without-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.without-arguments.js
+//            ^^^^^^^^^^^^^^^^^^^^^ meta.type-arguments.flowtype
+//            ^                   ^ punctuation.flowtype
+//             ^^^ support.type.class.flowtype
+//                ^      ^ punctuation.flowtype
+//                 ^^^^^^ support.type.builtin.primitive.flowtype
+//                        ^ meta.delimiter.comma.js
+//                          ^^^^^^ support.type.builtin.primitive.flowtype
+//                                 ^^  meta.brace.round.js
+//                                   ^ punctuation.terminator.statement.js
+
+new MyInstance("hi");
+// <- meta.new-class.with-arguments.js keyword.operator.new.js
+ // <- meta.new-class.with-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^  meta.new-class.with-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.with-arguments.js
+//            ^  meta.brace.round.js
+//                 ^  meta.brace.round.js
+//                  ^ punctuation.terminator.statement.js
+
+new MyInstance<string>("hi");
+// <- meta.new-class.with-arguments.js keyword.operator.new.js
+ // <- meta.new-class.with-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^  meta.new-class.with-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.with-arguments.js
+//            ^^^^^^^^ meta.type-arguments.flowtype
+//            ^ punctuation.flowtype
+//             ^^^^^^ support.type.builtin.primitive.flowtype
+//                   ^ punctuation.flowtype
+//                    ^  meta.brace.round.js
+//                         ^  meta.brace.round.js
+//                          ^ punctuation.terminator.statement.js
+
+new MyInstance < string > ("hi");
+// <- meta.new-class.with-arguments.js keyword.operator.new.js
+ // <- meta.new-class.with-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^  meta.new-class.with-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.with-arguments.js
+//             ^^^^^^^^^^ meta.type-arguments.flowtype
+//             ^        ^ punctuation.flowtype
+//               ^^^^^^ support.type.builtin.primitive.flowtype
+//                        ^    ^ meta.brace.round.js
+//                              ^ punctuation.terminator.statement.js
+
+new MyInstance<Baz<string>, number>("hi");
+// <- meta.new-class.with-arguments.js keyword.operator.new.js
+ // <- meta.new-class.with-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.new-class.with-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.with-arguments.js
+//            ^^^^^^^^^^^^^^^^^^^^^ meta.type-arguments.flowtype
+//            ^                   ^ punctuation.flowtype
+//             ^^^ support.type.class.flowtype
+//                ^      ^ punctuation.flowtype
+//                 ^^^^^^ support.type.builtin.primitive.flowtype
+//                        ^ meta.delimiter.comma.js
+//                          ^^^^^^ support.type.builtin.primitive.flowtype
+//                                 ^    ^  meta.brace.round.js
+//                                       ^ punctuation.terminator.statement.js
+
+myFunction();
+// <- meta.function-call.without-arguments.js
+ // <- meta.function-call.without-arguments.js
+//  ^^^^^^^^  meta.function-call.without-arguments.js
+//  ^^^^^^ entity.name.function.js
+//        ^^  meta.brace.round.js
+//          ^ punctuation.terminator.statement.js
+
+myFunction<string>();
+// <- meta.function-call.without-arguments.js
+ // <- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//  ^^^^^^ entity.name.function.js
+//  ^^^^^^ meta.function-call.without-arguments.js
+//        ^^^^^^^^ meta.type-arguments.flowtype
+//        ^ punctuation.flowtype
+//         ^^^^^^ support.type.builtin.primitive.flowtype
+//               ^ punctuation.flowtype
+//                ^^  meta.brace.round.js
+//                  ^ punctuation.terminator.statement.js
+
+myFunction < string > ();
+// <- meta.function-call.without-arguments.js
+ // <- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//  ^^^^^^ entity.name.function.js
+//  ^^^^^^ meta.function-call.without-arguments.js
+//         ^^^^^^^^^^ meta.type-arguments.flowtype
+//         ^        ^ punctuation.flowtype
+//           ^^^^^^ support.type.builtin.primitive.flowtype
+//                    ^^  meta.brace.round.js
+//                      ^ punctuation.terminator.statement.js
+
+myFunction<Baz<string>, number>();
+// <- meta.function-call.without-arguments.js
+ // <- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//  ^^^^^^ entity.name.function.js
+//  ^^^^^^ meta.function-call.without-arguments.js
+//        ^^^^^^^^^^^^^^^^^^^^^ meta.type-arguments.flowtype
+//        ^                   ^ punctuation.flowtype
+//         ^^^ support.type.class.flowtype
+//            ^      ^ punctuation.flowtype
+//             ^^^^^^ support.type.builtin.primitive.flowtype
+//                    ^ meta.delimiter.comma.js
+//                      ^^^^^^ support.type.builtin.primitive.flowtype
+//                            ^ punctuation.flowtype
+//                             ^^  meta.brace.round.js
+//                               ^ punctuation.terminator.statement.js
+
+myObject[myProp]();
+// <- meta.function-call.without-arguments.js
+ // <- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^^ meta.brace.round.js
+//                ^ punctuation.terminator.statement.js
+
+myObject[myProp]<string>();
+// <- meta.function-call.without-arguments.js
+ // <- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^      ^ punctuation.flowtype
+//               ^^^^^^ support.type.builtin.primitive.flowtype
+//                      ^^ meta.brace.round.js
+//                        ^ punctuation.terminator.statement.js
+
+myObject[myProp] < string > ();
+// <- meta.function-call.without-arguments.js
+ // <- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//               ^        ^ punctuation.flowtype
+//                 ^^^^^^ support.type.builtin.primitive.flowtype
+//                          ^^ meta.brace.round.js
+//                            ^ punctuation.terminator.statement.js
+
+myObject[myProp]<Baz<string>, number>();
+// <- meta.function-call.without-arguments.js
+ // <- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^                   ^ punctuation.flowtype
+//               ^^^ support.type.class.flowtype
+//                  ^      ^ punctuation.flowtype
+//                   ^^^^^^ support.type.builtin.primitive.flowtype
+//                          ^ meta.delimiter.comma.js
+//                            ^^^^^^ support.type.builtin.primitive.flowtype
+//                                   ^^ meta.brace.round.js
+//                                     ^ punctuation.terminator.statement.js
+
+myFunction("hi");
+// <- meta.function-call.with-arguments.js
+ // <- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//  ^^^^^^ entity.name.function.js
+//        ^    ^  meta.brace.round.js
+//              ^ punctuation.terminator.statement.js
+
+myFunction<string>("hi");
+// <- meta.function-call.with-arguments.js
+ // <- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//  ^^^^^^ entity.name.function.js
+//        ^      ^ punctuation.flowtype
+//         ^^^^^^ support.type.builtin.primitive.flowtype
+//                ^    ^  meta.brace.round.js
+//                      ^ punctuation.terminator.statement.js
+
+myFunction < string > ("hi");
+// <- meta.function-call.with-arguments.js
+ // <- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//  ^^^^^^ entity.name.function.js
+//         ^        ^ punctuation.flowtype
+//           ^^^^^^ support.type.builtin.primitive.flowtype
+//                    ^    ^  meta.brace.round.js
+//                          ^ punctuation.terminator.statement.js
+
+myFunction<Baz<number>, string>("hi");
+// <- meta.function-call.with-arguments.js
+ // <- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//  ^^^^^^ entity.name.function.js
+//        ^                   ^ punctuation.flowtype
+//         ^^^ support.type.class.flowtype
+//            ^      ^ punctuation.flowtype
+//             ^^^^^^ support.type.builtin.primitive.flowtype
+//                    ^ meta.delimiter.comma.js
+//                      ^^^^^^ support.type.builtin.primitive.flowtype
+//                             ^    ^  meta.brace.round.js
+//                                   ^ punctuation.terminator.statement.js
+
+myObject[myProp]("hi");
+// <- meta.function-call.with-arguments.js
+ // <- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^    ^ meta.brace.round.js
+//                    ^ punctuation.terminator.statement.js
+
+myObject[myProp]<string>("hi");
+// <- meta.function-call.with-arguments.js
+ // <- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^      ^ punctuation.flowtype
+//               ^^^^^^ support.type.builtin.primitive.flowtype
+//                      ^    ^ meta.brace.round.js
+//                            ^ punctuation.terminator.statement.js
+
+myObject[myProp] < string > ("hi");
+// <- meta.function-call.with-arguments.js
+ // <- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//               ^        ^ punctuation.flowtype
+//                 ^^^^^^ support.type.builtin.primitive.flowtype
+//                          ^    ^ meta.brace.round.js
+//                                ^ punctuation.terminator.statement.js
+
+myObject[myProp]<Baz<string>, number>("hi");
+// <- meta.function-call.with-arguments.js
+ // <- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^                   ^ punctuation.flowtype
+//               ^^^ support.type.class.flowtype
+//                  ^      ^ punctuation.flowtype
+//                   ^^^^^^ support.type.builtin.primitive.flowtype
+//                          ^ meta.delimiter.comma.js
+//                            ^^^^^^ support.type.builtin.primitive.flowtype
+//                                   ^    ^ meta.brace.round.js
+//                                         ^ punctuation.terminator.statement.js
+
+new MyInstance<Baz<string>, number>() < 123;
+new MyInstance<Baz<string>, number>("hi") < 123;
+myFunction<Baz<string>, number>() < 123;
+myObject[myProp]<Baz<string>, number>() < 123;
+myObject<Baz<string>, number>("hi") < 123;
+
+// >> only:(source.js.jsx)

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -19,6 +19,7 @@ describe 'Grammar', ->
 
   # babel-sublime test files
   grammarTest path.join(__dirname, 'fixtures/grammar/babel-sublime/flow.js')
+  grammarTest path.join(__dirname, 'fixtures/grammar/babel-sublime/flow-function-call-with-type-arguments.js')
   grammarTest path.join(__dirname, 'fixtures/grammar/babel-sublime/js-class.js')
   grammarTest path.join(__dirname, 'fixtures/grammar/babel-sublime/js-functions.js')
   grammarTest path.join(__dirname, 'fixtures/grammar/babel-sublime/js-symbols.js')


### PR DESCRIPTION
In Flow, you can call a function an explicitly specify the types for the generics. For example

```javascript
function foo<A, B>(a: A, b: B): void {}

foo<string, number>("hello", 123);
```

This PR attempts to update language-babel to support this syntax. It's a little complicated, since the grammar is somewhat ambiguous. For example, `foo < bar > (123)` is a valid expression in JavaScript, but Flow interprets it as a call expression with type parameters.