### PR TITLE
Add callbacks to fs.unlink(). fixes #525.

### DIFF
--- a/lib/auto-indent.coffee
+++ b/lib/auto-indent.coffee
@@ -39,7 +39,7 @@ module.exports =
 class AutoIndent
   constructor: (@editor) ->
     @DidInsertText = new DidInsertText(@editor)
-    @autoJsx = atom.config.get('language-babel').autoIndentJSX
+    @autoJsx = atom.config.get('language-babel.autoIndentJSX')
     # regex to search for tag open/close tag and close tag
     @JSXREGEXP = /(<)([$_A-Za-z](?:[$_.:\-A-Za-z0-9])*)|(\/>)|(<\/)([$_A-Za-z](?:[$._:\-A-Za-z0-9])*)(>)|(>)|({)|(})|(\?)|(:)|(if)|(else)|(case)|(default)|(return)|(\()|(\))|(`)|(?:(<)\s*(>))|(<\/)(>)/g
     @mouseUp = true

--- a/lib/create-ttl-grammar.js
+++ b/lib/create-ttl-grammar.js
@@ -169,7 +169,7 @@ module.exports = class CreateTtlGrammar {
 
   // read configurations for tagged templates
   getTtlConfig() {
-    return atom.config.get('language-babel').taggedTemplateGrammar;
+    return atom.config.get('language-babel.taggedTemplateGrammar');
   }
 
   // get an array of grammar tagged template extension filenames

--- a/lib/create-ttl-grammar.js
+++ b/lib/create-ttl-grammar.js
@@ -255,10 +255,15 @@ module.exports = class CreateTtlGrammar {
   // remove all language files in tagged template GrammarFiles array
   removeTtlLanguageFiles() {
     return this.getTtlGrammarFiles().then(ttlGrammarFiles => {
-      for (let ttlGrammarFilename of ttlGrammarFiles) {
-        let ttlGrammarFileAbsoulte = this.makeTtlGrammarFilenameAbsoulute(ttlGrammarFilename);
-        fs.unlink(ttlGrammarFileAbsoulte);
-      }
+      return Promise.all(ttlGrammarFiles.map((ttlGrammarFilename) =>
+        new Promise ((resolve, reject) => {
+          let ttlGrammarFileAbsoulte = this.makeTtlGrammarFilenameAbsoulute(ttlGrammarFilename);
+          fs.unlink(ttlGrammarFileAbsoulte, (err) => {
+            if (err) return reject(err);
+            resolve();
+          });
+        })
+      ))
     });
   }
 };

--- a/src/create-ttl-grammar.js
+++ b/src/create-ttl-grammar.js
@@ -178,7 +178,7 @@ class CreateTtlGrammar {
 
   // read configurations for tagged templates
   getTtlConfig() {
-    return atom.config.get('language-babel').taggedTemplateGrammar;
+    return atom.config.get('language-babel.taggedTemplateGrammar');
   }
 
   // get an array of grammar tagged template extension filenames

--- a/src/create-ttl-grammar.js
+++ b/src/create-ttl-grammar.js
@@ -265,12 +265,16 @@ class CreateTtlGrammar {
 
   // remove all language files in tagged template GrammarFiles array
   removeTtlLanguageFiles() {
-    return this.getTtlGrammarFiles().then((ttlGrammarFiles) => {
-      for (let ttlGrammarFilename of ttlGrammarFiles) {
-        let ttlGrammarFileAbsoulte = this.makeTtlGrammarFilenameAbsoulute(ttlGrammarFilename);
-        fs.unlink(ttlGrammarFileAbsoulte);
-      }
+    return this.getTtlGrammarFiles().then(ttlGrammarFiles => {
+      return Promise.all(ttlGrammarFiles.map((ttlGrammarFilename) => {
+        return new Promise ((resolve, reject) => {
+          let ttlGrammarFileAbsoulte = this.makeTtlGrammarFilenameAbsoulute(ttlGrammarFilename);
+          fs.unlink(ttlGrammarFileAbsoulte, (err) => {
+            if (err) return reject(err);
+            resolve();
+          });
+        });
+      }))
     });
-
   }
 };


### PR DESCRIPTION
Following the hints provided by @christiaanwesterbeek [here](https://github.com/gandm/language-babel/issues/525#issuecomment-542096565), I succesfully implemented a fix for issue #525.

I tried to do it right, and didn't choose the lazy way of just switching to a `unlinkSync`.